### PR TITLE
[MST-792] Add update_verification_attempt_id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,4 +14,4 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 * Initialize project along with `VerifiedName` model.
-* Create API methods `create_verified_name` and `get_verified_name`.
+* Create API methods `create_verified_name`, `get_verified_name`, and `update_verification_attempt_id`.

--- a/edx_name_affirmation/exceptions.py
+++ b/edx_name_affirmation/exceptions.py
@@ -3,6 +3,12 @@ Custom exceptions for edx_name_affirmation.
 """
 
 
+class VerifiedNameDoesNotExist(Exception):
+    """
+    The requested VerifiedName does not exist.
+    """
+
+
 class VerifiedNameEmptyString(Exception):
     """
     An empty string was supplied for verified_name or profile_name.


### PR DESCRIPTION
[MST-792](https://openedx.atlassian.net/browse/MST-792)

Adds `update_verification_attempt_id` to the VerifiedName API. This will update the user's most recent VerifiedName - this allows the user to create a VerifiedName, and finish ID verification later.

If the most recent VerifiedName already has a linked verification or proctored exam attempt, a new VerifiedName will be created instead.

It will raise an exception if the user does not have an existing VerifiedName.