### PR TITLE
[MST-837] Add update_is_verified_status

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ branch = True
 data_file = .coverage
 source=edx_name_affirmation
 omit =
-    tests
+    */migrations/*

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,4 +14,5 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 * Initialize project along with `VerifiedName` model.
-* Create API methods `create_verified_name`, `get_verified_name`, and `update_verification_attempt_id`.
+* Create API methods `create_verified_name`, `get_verified_name`, `update_verification_attempt_id`,
+  and `update_is_verified_status`.

--- a/edx_name_affirmation/exceptions.py
+++ b/edx_name_affirmation/exceptions.py
@@ -35,3 +35,10 @@ class VerifiedNameMultipleAttemptIds(Exception):
     Both a verification_attempt_id and proctored_exam_attempt_id were supplied for
     the same VerifiedName.
     """
+
+
+class VerifiedNameAttemptIdNotGiven(Exception):
+    """
+    Neither a verification_attempt_id or a proctored_exam_attempt_id was given for a
+    function that requires it.
+    """


### PR DESCRIPTION
[MST-837](https://openedx.atlassian.net/browse/MST-837)

Provide a way to update the `is_verified` status of a VerifiedName, intended for use when the linked ID verification or proctored exam attempt is approved.