### PR TITLE
feat: add post endpoint for VerifiedName

### DIFF
--- a/edx_name_affirmation/serializers.py
+++ b/edx_name_affirmation/serializers.py
@@ -1,6 +1,5 @@
 """Defines serializers used by the Name Affirmation API"""
 from rest_framework import serializers
-from rest_framework.fields import DateTimeField
 
 from django.contrib.auth import get_user_model
 
@@ -9,34 +8,16 @@ from edx_name_affirmation.models import VerifiedName
 User = get_user_model()
 
 
-class UserSerializer(serializers.ModelSerializer):
-    """
-    Serializer for the User Model.
-    """
-    id = serializers.IntegerField(required=False)  # pylint: disable=invalid-name
-    username = serializers.CharField(required=True)
-    email = serializers.CharField(required=True)
-
-    class Meta:
-        """
-        Meta Class
-        """
-        model = User
-
-        fields = (
-            "id", "username", "email"
-        )
-
-
 class VerifiedNameSerializer(serializers.ModelSerializer):
     """
     Serializer for the VerifiedName Model.
     """
-    user = UserSerializer()
-    created = DateTimeField(format=None)
+    username = serializers.CharField(source="user.username")
     verified_name = serializers.CharField(required=True)
-    verification_attempt_id = serializers.IntegerField(required=True, allow_null=True)
-    proctored_exam_attempt_id = serializers.IntegerField(required=True, allow_null=True)
+    profile_name = serializers.CharField(required=True)
+    verification_attempt_id = serializers.IntegerField(required=False, allow_null=True)
+    proctored_exam_attempt_id = serializers.IntegerField(required=False, allow_null=True)
+    is_verified = serializers.BooleanField(required=False, allow_null=True)
 
     class Meta:
         """
@@ -45,6 +26,6 @@ class VerifiedNameSerializer(serializers.ModelSerializer):
         model = VerifiedName
 
         fields = (
-            "id", "modified", "created", "user", "verified_name", "profile_name", "verification_attempt_id",
+            "created", "username", "verified_name", "profile_name", "verification_attempt_id",
             "proctored_exam_attempt_id", "is_verified"
         )

--- a/edx_name_affirmation/views.py
+++ b/edx_name_affirmation/views.py
@@ -11,7 +11,8 @@ from rest_framework.views import APIView
 
 from django.contrib.auth import get_user_model
 
-from edx_name_affirmation.api import get_verified_name
+from edx_name_affirmation.api import create_verified_name, get_verified_name
+from edx_name_affirmation.exceptions import VerifiedNameMultipleAttemptIds
 from edx_name_affirmation.serializers import VerifiedNameSerializer
 
 
@@ -25,8 +26,28 @@ class AuthenticatedAPIView(APIView):
 
 class VerifiedNameView(AuthenticatedAPIView):
     """
-    Endpoint for getting a verified name and its data.
+    Endpoint for a VerifiedName.
     /edx_name_affirmation/v1/verified_name?username=xxx
+
+    Supports:
+        HTTP POST: Creates a new VerifiedName.
+        HTTP GET: Returns an existing VerifiedName (by username or requesting user)
+
+    HTTP POST
+    Creates a new VerifiedName.
+    Expected POST data: {
+        "username": "jdoe",
+        "verified_name": "Jonathan Doe"
+        "profile_name": "Jon Doe"
+        "verification_attempt_id": (Optional)
+        "proctored_exam_attempt_id": (Optional)
+        "is_verified": (Optional)
+    }
+
+    HTTP GET
+        ** Scenarios **
+        ?username=jdoe
+        returns an existing verified name object matching the username
     """
     def get(self, request):
         """
@@ -50,3 +71,36 @@ class VerifiedNameView(AuthenticatedAPIView):
 
         serialized_data = VerifiedNameSerializer(verified_name).data
         return Response(serialized_data)
+
+    def post(self, request):
+        """
+        Create verified name
+        """
+        username = request.data.get('username')
+        if username != request.user.username and not request.user.is_staff:
+            return Response(
+                status=status.HTTP_403_FORBIDDEN,
+                data={"detail": "Must be a Staff User to Perform this request."}
+            )
+
+        serializer = VerifiedNameSerializer(data=request.data)
+        if serializer.is_valid():
+            user = get_user_model().objects.get(username=username) if username else request.user
+            try:
+                create_verified_name(
+                    user,
+                    request.data.get('verified_name'),
+                    request.data.get('profile_name'),
+                    verification_attempt_id=request.data.get('verification_attempt_id', None),
+                    proctored_exam_attempt_id=request.data.get('proctored_exam_attempt_id', None),
+                    is_verified=request.data.get('is_verified', False)
+                )
+                response_status = status.HTTP_200_OK
+                data = {}
+            except VerifiedNameMultipleAttemptIds as exc:
+                response_status = status.HTTP_400_BAD_REQUEST
+                data = {"detail": str(exc)}
+        else:
+            response_status = status.HTTP_400_BAD_REQUEST
+            data = serializer.errors
+        return Response(status=response_status, data=data)


### PR DESCRIPTION
## [MST-796](https://openedx.atlassian.net/browse/MST-796)

Add post endpoint to create new verified name. Endpoint will return:
* 403 if non-staff user is attempting to create a verified name for another user
* 400 if both `proctored_exam_attempt_id` and `verification_attempt_id` are included in request
* 400 if data is invalid