### PR TITLE
[MST-883] Add plugin support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.1.2] - 2021-07-02
+~~~~~~~~~~~~~~~~~~~~
+* Add plugin support.
+
 [0.1.1] - 2021-06-30
 ~~~~~~~~~~~~~~~~~~~~
 * Fix typo in publish-pypi job.

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/apps.py
+++ b/edx_name_affirmation/apps.py
@@ -11,3 +11,13 @@ class EdxNameAffirmationConfig(AppConfig):
     """
 
     name = 'edx_name_affirmation'
+
+    plugin_app = {
+        'url_config': {
+            'lms.djangoapp': {
+                'namespace': 'edx_name_affirmation',
+                'regex': '^api/',
+                'relative_path': 'urls',
+            }
+        }
+    }


### PR DESCRIPTION
[MST-883](MST-883)

Adds plugin support as described in [edx-django-utils](https://github.com/edx/edx-django-utils/tree/master/edx_django_utils/plugins).