### PR TITLE
feat: Update get verified name to use optional attempt IDs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[0.2.0] - 2020-07-14
+~~~~~~~~~~~~~~~~~~~~
+* Update `get_verified_name` to include the ability to get by attempt ID.
 * Add PR template
 
 [0.1.2] - 2021-07-02

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.1.2'
+__version__ = '0.2.0'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/tests/test_api.py
+++ b/edx_name_affirmation/tests/test_api.py
@@ -146,6 +146,43 @@ class TestVerifiedNameAPI(TestCase):
 
         self.assertIsNone(verified_name_obj)
 
+    @ddt.data(
+        (VERIFICATION_ATTEMPT_ID, None),
+        (None, PROCTORED_EXAM_ATTEMPT_ID),
+    )
+    @ddt.unpack
+    def test_get_verified_name_by_attempt_id(self, verification_attempt_id, proctored_exam_attempt_id):
+        """
+        Test to get a verified name by an attempt ID.
+        """
+        if verification_attempt_id:
+            target_verified_name = self._create_verified_name(verification_attempt_id=verification_attempt_id)
+        if proctored_exam_attempt_id:
+            target_verified_name = self._create_verified_name(proctored_exam_attempt_id=proctored_exam_attempt_id)
+        self._create_verified_name()
+
+        verified_name_obj = get_verified_name(
+            self.user,
+            verification_attempt_id=verification_attempt_id,
+            proctored_exam_attempt_id=proctored_exam_attempt_id,
+        )
+
+        self.assertEqual(target_verified_name.id, verified_name_obj.id)
+
+    def test_get_verified_name_by_two_attempt_ids(self):
+        """
+        Test that an exception is raised if trying to get a verified name by two different attempt IDs.
+        """
+        self._create_verified_name(verification_attempt_id=self.VERIFICATION_ATTEMPT_ID)
+        self._create_verified_name(proctored_exam_attempt_id=self.PROCTORED_EXAM_ATTEMPT_ID)
+
+        with self.assertRaises(VerifiedNameMultipleAttemptIds):
+            get_verified_name(
+                self.user,
+                verification_attempt_id=self.VERIFICATION_ATTEMPT_ID,
+                proctored_exam_attempt_id=self.PROCTORED_EXAM_ATTEMPT_ID,
+            )
+
     def test_update_verification_attempt_id(self):
         """
         Test that the most recent VerifiedName is updated with a verification_attempt_id if


### PR DESCRIPTION
Update `get_verified_name` to include the optional parameters `verification_attempt_id` or `proctored_exam_attempt_id`.