### PR TITLE
feat: Add verified_name_enabled to VerifiedNameView GET response

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,13 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
-* Add PR template
-* Add VerifiedNameConfig model and API functions
+
+
+[0.2.0] - 2021-07-22
+~~~~~~~~~~~~~~~~~~~~
+* Add verified_name_enabled to VerifiedNameView GET response.
+* Add PR template.
+* Add VerifiedNameConfig model and API functions.
 
 [0.1.2] - 2021-07-02
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.1.2'
+__version__ = '0.2.0'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/views.py
+++ b/edx_name_affirmation/views.py
@@ -14,6 +14,7 @@ from django.contrib.auth import get_user_model
 from edx_name_affirmation.api import create_verified_name, get_verified_name
 from edx_name_affirmation.exceptions import VerifiedNameMultipleAttemptIds
 from edx_name_affirmation.serializers import VerifiedNameSerializer
+from edx_name_affirmation.toggles import is_verified_name_enabled
 
 
 class AuthenticatedAPIView(APIView):
@@ -70,6 +71,7 @@ class VerifiedNameView(AuthenticatedAPIView):
             )
 
         serialized_data = VerifiedNameSerializer(verified_name).data
+        serialized_data['verified_name_enabled'] = is_verified_name_enabled()
         return Response(serialized_data)
 
     def post(self, request):


### PR DESCRIPTION
**Description:**

Adds an attribute to the GET response of the VerifiedNameView view, indicating whether the verified name feature is enabled.

**JIRA:**
[MST-800](https://openedx.atlassian.net/browse/MST-800)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
