### PR TITLE
[MST-893] Update REST API to include config model

### DIFF
--- a/.annotation_safe_list.yml
+++ b/.annotation_safe_list.yml
@@ -6,6 +6,8 @@ waffle.Sample:
     ".. no_pii:": "This model has no PII"
 waffle.Switch:
     ".. no_pii:": "This model has no PII"
+admin.LogEntry:
+    ".. no_pii:": "This model has no PII"
 contenttypes.ContentType:
     ".. no_pii:": "This model has no PII"
 auth.User:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.3.0] - 2021-08-02
+~~~~~~~~~~~~~~~~~~~~
+* Add `use_verified_name_for_certs` field to the VerifiedNameView
+  response, and create a new endpoint to update the user's verified
+  name config.
+* Admin page configuration for VerifiedName and VerifiedNameConfig.
 
 [0.2.0] - 2021-07-22
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/admin.py
+++ b/edx_name_affirmation/admin.py
@@ -1,0 +1,34 @@
+"""
+Custom Django admin pages for Name Affirmation
+"""
+
+from django.contrib import admin
+
+from edx_name_affirmation.models import VerifiedName, VerifiedNameConfig
+
+
+class VerifiedNameAdmin(admin.ModelAdmin):
+    """
+    Admin for the VerifiedName Model
+    """
+    list_display = (
+      'id', 'user', 'verified_name', 'verification_attempt_id', 'proctored_exam_attempt_id',
+      'is_verified', 'created', 'modified',
+    )
+    readonly_fields = ('id', 'user', 'created', 'modified')
+    search_fields = ('user__username', 'verification_attempt_id', 'proctored_exam_attempt_id',)
+
+
+class VerifiedNameConfigAdmin(admin.ModelAdmin):
+    """
+    Admin for the VerifiedNameConfig Model
+    """
+    list_display = (
+      'id', 'user', 'use_verified_name_for_certs', 'change_date',
+    )
+    readonly_fields = ('change_date',)
+    search_fields = ('user__username',)
+
+
+admin.site.register(VerifiedName, VerifiedNameAdmin)
+admin.site.register(VerifiedNameConfig, VerifiedNameConfigAdmin)

--- a/edx_name_affirmation/api.py
+++ b/edx_name_affirmation/api.py
@@ -223,6 +223,12 @@ def create_verified_name_config(user, use_verified_name_for_certs=None):
           the user's verified name over their profile name.
     """
     fields = {'user': user}
+
+    # Default to the values from the most recent config
+    existing_config = VerifiedNameConfig.objects.filter(user=user).order_by('-change_date').first()
+    if existing_config:
+        fields['use_verified_name_for_certs'] = existing_config.use_verified_name_for_certs
+
     if use_verified_name_for_certs is not None:
         fields['use_verified_name_for_certs'] = use_verified_name_for_certs
 

--- a/edx_name_affirmation/serializers.py
+++ b/edx_name_affirmation/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 
 from django.contrib.auth import get_user_model
 
-from edx_name_affirmation.models import VerifiedName
+from edx_name_affirmation.models import VerifiedName, VerifiedNameConfig
 
 User = get_user_model()
 
@@ -29,3 +29,19 @@ class VerifiedNameSerializer(serializers.ModelSerializer):
             "created", "username", "verified_name", "profile_name", "verification_attempt_id",
             "proctored_exam_attempt_id", "is_verified"
         )
+
+
+class VerifiedNameConfigSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the VerifiedNameConfig Model.
+    """
+    username = serializers.CharField(source="user.username")
+    use_verified_name_for_certs = serializers.BooleanField(required=False, allow_null=True)
+
+    class Meta:
+        """
+        Meta Class
+        """
+        model = VerifiedNameConfig
+
+        fields = ("change_date", "username", "use_verified_name_for_certs")

--- a/edx_name_affirmation/tests/test_admin.py
+++ b/edx_name_affirmation/tests/test_admin.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for the NameAffirmation admin classes
+"""
+
+
+from unittest import mock
+
+from django.contrib.admin.sites import AdminSite
+from django.test import TestCase
+
+from edx_name_affirmation.admin import VerifiedNameAdmin, VerifiedNameConfigAdmin
+from edx_name_affirmation.models import VerifiedName, VerifiedNameConfig
+
+
+class NameAffirmationAdminTests(TestCase):
+    """
+    Unit tests for the NameAffirmation admin classes
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.verified_name_admin = VerifiedNameAdmin(VerifiedName, AdminSite())
+        self.verified_name_config_admin = VerifiedNameConfigAdmin(
+            VerifiedNameConfig, AdminSite()
+        )
+
+    def test_verified_name_admin(self):
+        request = mock.Mock()
+
+        expected_list_display = (
+            'id', 'user', 'verified_name', 'verification_attempt_id', 'proctored_exam_attempt_id',
+            'is_verified', 'created', 'modified',
+        )
+        self.assertEqual(
+            expected_list_display,
+            self.verified_name_admin.get_list_display(request)
+        )
+
+        expected_readonly_fields = ('id', 'user', 'created', 'modified')
+        self.assertEqual(
+            expected_readonly_fields,
+            self.verified_name_admin.get_readonly_fields(request)
+        )
+
+        expected_search_fields = (
+            'user__username', 'verification_attempt_id', 'proctored_exam_attempt_id',
+        )
+        self.assertEqual(
+            expected_search_fields,
+            self.verified_name_admin.get_search_fields(request)
+        )
+
+    def test_verified_name_config_admin(self):
+        request = mock.Mock()
+
+        expected_list_display = (
+            'id', 'user', 'use_verified_name_for_certs', 'change_date',
+        )
+        self.assertEqual(
+            expected_list_display,
+            self.verified_name_config_admin.get_list_display(request)
+        )
+
+        expected_readonly_fields = ('change_date',)
+        self.assertEqual(
+            expected_readonly_fields,
+            self.verified_name_config_admin.get_readonly_fields(request)
+        )
+
+        expected_search_fields = ('user__username',)
+        self.assertEqual(
+            expected_search_fields,
+            self.verified_name_config_admin.get_search_fields(request)
+        )

--- a/edx_name_affirmation/urls.py
+++ b/edx_name_affirmation/urls.py
@@ -13,5 +13,12 @@ urlpatterns = [
         views.VerifiedNameView.as_view(),
         name='verified_name'
     ),
+
+    url(
+        r'edx_name_affirmation/v1/verified_name/config$',
+        views.VerifiedNameConfigView.as_view(),
+        name='verified_name_config'
+    ),
+
     url(r'^', include('rest_framework.urls', namespace='rest_framework')),
 ]

--- a/test_settings.py
+++ b/test_settings.py
@@ -28,6 +28,7 @@ DATABASES = {
 
 INSTALLED_APPS = (
     'config_models',
+    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',


### PR DESCRIPTION
**Description:**

Add `use_verified_name_for_certs` field to the VerifiedNameView response, and create a new endpoint to update the user's verified name config.

Also added admin pages for VerifiedName and VerifiedNameConfig as they had not been configured yet.

**JIRA:**

[MST-893](https://openedx.atlassian.net/browse/MST-893)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
