### PR TITLE
[MST-949] Add missing graft command to MANIFEST.in

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.3.1] - 2021-08-03
+~~~~~~~~~~~~~~~~~~~~
+* Update `MANIFEST.in` to include all directories under `edx_name_affirmation`.
+
 [0.3.0] - 2021-08-02
 ~~~~~~~~~~~~~~~~~~~~
 * Add `use_verified_name_for_certs` field to the VerifiedNameView

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.rst
 include CHANGELOG.rst
-include requirements/base.in
-include requirements/test.in
+graft edx_name_affirmation
+recursive-include requirements *.in *.txt
+global-exclude *.pyc

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:**

The PyPI package was missing all files from the child directories in edx_name_affirmation (migrations, tests, etc). This should fix that.

**JIRA:**

[MST-949](https://openedx.atlassian.net/browse/MST-949)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
