### PR TITLE
[MST-945] Add verified name history API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.5.0] - 2021-08-11
+~~~~~~~~~~~~~~~~~~~~
+* Add API method and endpoint to return a complete list of the user's
+  VerifiedNames, ordered by most recently created.
+
 [0.4.0] - 2021-08-06
 ~~~~~~~~~~~~~~~~~~~~
 * Expose API methods through `NameAffirmationService`.

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/api.py
+++ b/edx_name_affirmation/api.py
@@ -94,6 +94,17 @@ def get_verified_name(user, is_verified=False):
     return verified_name_qs.first()
 
 
+def get_verified_name_history(user):
+    """
+    Return a QuerySet of all VerifiedNames for a given user, ordered by the date created from
+    most recent.
+
+    Arguments:
+        * `user` (User object)
+    """
+    return VerifiedName.objects.filter(user=user).order_by('-created')
+
+
 def update_verification_attempt_id(user, verification_attempt_id):
     """
     Update the `verification_attempt_id` for the user's most recent VerifiedName.

--- a/edx_name_affirmation/tests/test_api.py
+++ b/edx_name_affirmation/tests/test_api.py
@@ -12,6 +12,7 @@ from edx_name_affirmation.api import (
     create_verified_name,
     create_verified_name_config,
     get_verified_name,
+    get_verified_name_history,
     should_use_verified_name_for_certs,
     update_is_verified_status,
     update_verification_attempt_id
@@ -154,6 +155,18 @@ class TestVerifiedNameAPI(TestCase):
             verified_name_obj = get_verified_name(self.user)
 
         self.assertIsNone(verified_name_obj)
+
+    def test_get_verified_name_history(self):
+        """
+        Test that get_verified_name_history returns all of the user's VerifiedNames
+        ordered by most recently created.
+        """
+        verified_name_first = self._create_verified_name()
+        verified_name_second = self._create_verified_name()
+
+        verified_name_qs = get_verified_name_history(self.user)
+        self.assertEqual(verified_name_qs[1].id, verified_name_first.id)
+        self.assertEqual(verified_name_qs[0].id, verified_name_second.id)
 
     def test_update_verification_attempt_id(self):
         """

--- a/edx_name_affirmation/tests/test_views.py
+++ b/edx_name_affirmation/tests/test_views.py
@@ -247,11 +247,12 @@ class VerifiedNameHistoryViewTests(LoggedInTestCase):
         self.assertEqual(data, expected_response)
 
     def test_get_no_data(self):
+        expected_response = self._get_expected_response(self.user, [])
         response = self.client.get(reverse('edx_name_affirmation:verified_name_history'))
 
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(data, [])
+        self.assertEqual(data, expected_response)
 
     @ddt.data((True, 200), (False, 403))
     @ddt.unpack
@@ -294,7 +295,7 @@ class VerifiedNameHistoryViewTests(LoggedInTestCase):
         """
         Create and return a verified name QuerySet.
         """
-        expected_response = []
+        expected_response = {'results': []}
 
         for verified_name_obj in verified_name_history:
             data = {
@@ -306,7 +307,7 @@ class VerifiedNameHistoryViewTests(LoggedInTestCase):
                 'proctored_exam_attempt_id': verified_name_obj.proctored_exam_attempt_id,
                 'is_verified': verified_name_obj.is_verified
             }
-            expected_response.append(data)
+            expected_response['results'].append(data)
 
         return expected_response
 

--- a/edx_name_affirmation/urls.py
+++ b/edx_name_affirmation/urls.py
@@ -15,6 +15,12 @@ urlpatterns = [
     ),
 
     url(
+        r'edx_name_affirmation/v1/verified_name/history$',
+        views.VerifiedNameHistoryView.as_view(),
+        name='verified_name_history'
+    ),
+
+    url(
         r'edx_name_affirmation/v1/verified_name/config$',
         views.VerifiedNameConfigView.as_view(),
         name='verified_name_config'

--- a/edx_name_affirmation/views.py
+++ b/edx_name_affirmation/views.py
@@ -147,10 +147,8 @@ class VerifiedNameHistoryView(AuthenticatedAPIView):
 
         user = get_user_model().objects.get(username=username) if username else request.user
         verified_name_qs = get_verified_name_history(user)
-
-        serialized_data = [
-            VerifiedNameSerializer(verified_name).data for verified_name in verified_name_qs
-        ]
+        serializer = VerifiedNameSerializer(verified_name_qs, many=True)
+        serialized_data = {'results': serializer.data}
 
         return Response(serialized_data)
 


### PR DESCRIPTION
**Description:**

Add an API and endpoint to retrieve a list of all the user's verified names in order of most recently created.

**JIRA:**

[MST-945](https://openedx.atlassian.net/browse/MST-945)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
