### PR TITLE
fix: put enough admin support into the settings file to actually run

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.6.1] - 2021-08-17
+~~~~~~~~~~~~~~~~~~~~
+* Django settings updates for admin app
+
 [0.6.0] - 2021-08-11
 ~~~~~~~~~~~~~~~~~~~~
 * Add name verification status field, replacing single is_verified boolean.

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/test_settings.py
+++ b/test_settings.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.messages',
     'django.contrib.sessions',
     'edx_name_affirmation',
     'waffle',
@@ -51,3 +52,14 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
 )
+
+TEMPLATES = [{
+    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    'APP_DIRS': False,
+    'OPTIONS': {
+        'context_processors': [
+            'django.contrib.auth.context_processors.auth',  # this is required for admin
+            'django.contrib.messages.context_processors.messages',  # this is required for admin
+        ],
+    },
+}]


### PR DESCRIPTION
**Description:**

You can't run for example manage.py migrate right now without disabling admin in settings.

This seems to be the minimal set of changes required to get that to run again.

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
