### PR TITLE
feat: continue removing verified name is_verified

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.6.2] - 2021-08-17
+~~~~~~~~~~~~~~~~~~~~
+* Remove verified name is_verified from model
+
 [0.6.1] - 2021-08-17
 ~~~~~~~~~~~~~~~~~~~~
 * Django settings updates for admin app

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/models.py
+++ b/edx_name_affirmation/models.py
@@ -37,8 +37,6 @@ class VerifiedName(TimeStampedModel):
         choices=[(st.value, st.value) for st in VerifiedNameStatus],
         default=VerifiedNameStatus.PENDING.value,
     )
-    # is_verified is being removed
-    is_verified = models.BooleanField(default=False, null=True)
 
     class Meta:
         """ Meta class for this Django model """


### PR DESCRIPTION
Takes a few releases to safely get rid of the field.

MST-969


**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
