### PR TITLE
fix: update admin to use status instead of is_verified

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.6.3] - 2021-08-18
+~~~~~~~~~~~~~~~~~~~~
+* Update admin for verified name status
+
 [0.6.2] - 2021-08-17
 ~~~~~~~~~~~~~~~~~~~~
 * Remove verified name is_verified from model

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/admin.py
+++ b/edx_name_affirmation/admin.py
@@ -13,7 +13,7 @@ class VerifiedNameAdmin(admin.ModelAdmin):
     """
     list_display = (
       'id', 'user', 'verified_name', 'verification_attempt_id', 'proctored_exam_attempt_id',
-      'is_verified', 'created', 'modified',
+      'status', 'created', 'modified',
     )
     readonly_fields = ('id', 'user', 'created', 'modified')
     search_fields = ('user__username', 'verification_attempt_id', 'proctored_exam_attempt_id',)

--- a/edx_name_affirmation/tests/test_admin.py
+++ b/edx_name_affirmation/tests/test_admin.py
@@ -29,7 +29,7 @@ class NameAffirmationAdminTests(TestCase):
 
         expected_list_display = (
             'id', 'user', 'verified_name', 'verification_attempt_id', 'proctored_exam_attempt_id',
-            'is_verified', 'created', 'modified',
+            'status', 'created', 'modified',
         )
         self.assertEqual(
             expected_list_display,


### PR DESCRIPTION
This check doesn't happen until you actually run django i.e. manage.py makemigrations so I missed it in earlier PRs. We probably want an automated check that runs manage.py check.

Also I'm not thrilled with the test, it just compares lists of strings in the setup and test files. I think we could drop that entire test file and lose only coverage numbers - django admin is tested by django, we're just setting it up.

MST-969

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
