### PR TITLE
feat: Add verified_name_enabled and use_verified_name_for_certs to the GET response of VerifiedNameHistoryView.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.70] - 2021-08-26
+~~~~~~~~~~~~~~~~~~~~
+* Add verified_name_enabled and use_verified_name_for_certs to the GET response of VerifiedNameHistoryView.
+
 [0.6.4] - 2021-08-18
 ~~~~~~~~~~~~~~~~~~~~
 * Remove verified name is_verified from DB

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.6.4'
+__version__ = '0.7.0'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/tests/test_views.py
+++ b/edx_name_affirmation/tests/test_views.py
@@ -247,6 +247,21 @@ class VerifiedNameHistoryViewTests(LoggedInTestCase):
         data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(data, expected_response)
 
+    @override_waffle_flag(VERIFIED_NAME_FLAG, active=True)
+    def test_get_bools(self):
+        verified_name_history = self._create_verified_name_history(self.user)
+        expected_response = self._get_expected_response(
+            self.user, verified_name_history,
+            verified_name_enabled=True,
+            use_verified_name_for_certs=False
+        )
+
+        response = self.client.get(reverse('edx_name_affirmation:verified_name_history'))
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(data, expected_response)
+
     def test_get_no_data(self):
         expected_response = self._get_expected_response(self.user, [])
         response = self.client.get(reverse('edx_name_affirmation:verified_name_history'))
@@ -292,11 +307,21 @@ class VerifiedNameHistoryViewTests(LoggedInTestCase):
         )
         return get_verified_name_history(user)
 
-    def _get_expected_response(self, user, verified_name_history):
+    def _get_expected_response(
+        self,
+        user,
+        verified_name_history,
+        verified_name_enabled=False,
+        use_verified_name_for_certs=False
+    ):
         """
         Create and return a verified name QuerySet.
         """
-        expected_response = {'results': []}
+        expected_response = {
+            'results': [],
+            'verified_name_enabled': verified_name_enabled,
+            'use_verified_name_for_certs': use_verified_name_for_certs,
+        }
 
         for verified_name_obj in verified_name_history:
             data = {

--- a/edx_name_affirmation/views.py
+++ b/edx_name_affirmation/views.py
@@ -86,11 +86,10 @@ class VerifiedNameView(AuthenticatedAPIView):
                 data={'detail': 'There is no verified name related to this user.'}
 
             )
-        use_verified_name_for_certs = should_use_verified_name_for_certs(user)
 
         serialized_data = VerifiedNameSerializer(verified_name).data
         serialized_data['verified_name_enabled'] = is_verified_name_enabled()
-        serialized_data['use_verified_name_for_certs'] = use_verified_name_for_certs
+        serialized_data['use_verified_name_for_certs'] = should_use_verified_name_for_certs(user)
         return Response(serialized_data)
 
     def post(self, request):
@@ -149,7 +148,12 @@ class VerifiedNameHistoryView(AuthenticatedAPIView):
         user = get_user_model().objects.get(username=username) if username else request.user
         verified_name_qs = get_verified_name_history(user)
         serializer = VerifiedNameSerializer(verified_name_qs, many=True)
-        serialized_data = {'results': serializer.data}
+
+        serialized_data = {
+            'verified_name_enabled': is_verified_name_enabled(),
+            'use_verified_name_for_certs': should_use_verified_name_for_certs(user),
+            'results': serializer.data,
+        }
 
         return Response(serialized_data)
 


### PR DESCRIPTION
**Description:**

The Account Settings page will transition to using the VerifiedNameHistoryVieew instead of the VerifiedNameView. Therefore, information about whether the verified name feature is enabled and whether a user's verified name is selected for use by certificates is relevant information that should be passed in the response.

**JIRA:**

[MST-954](https://openedx.atlassian.net/browse/MST-954)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
