### PR TITLE
fix: Correct CHANGELOG version from 0.70 to 0.7.0.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-[0.70] - 2021-08-26
+[0.7.0] - 2021-08-26
 ~~~~~~~~~~~~~~~~~~~~
 * Add verified_name_enabled and use_verified_name_for_certs to the GET response of VerifiedNameHistoryView.
 


### PR DESCRIPTION
**Description:**

This corrects a typo in the CHANGELOG.

**JIRA:**

[MST-954](https://openedx.atlassian.net/browse/MST-954)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
