### PR TITLE
[MST-803] Add signal handler for verified name approved

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.8.1] - 2021-08-30
+~~~~~~~~~~~~~~~~~~~~
+* Emit signal when `VerifiedName` status changes to "approved".
+
 [0.8.0] - 2021-08-30
 ~~~~~~~~~~~~~~~~~~~~
 * Add signal receivers for IDV and proctoring attempts

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/apps.py
+++ b/edx_name_affirmation/apps.py
@@ -36,3 +36,9 @@ class EdxNameAffirmationConfig(AppConfig):
             }
         }
     }
+
+    def ready(self):
+        """
+        Connect signal handlers.
+        """
+        from . import handlers  # pylint: disable=import-outside-toplevel,unused-import

--- a/edx_name_affirmation/signals.py
+++ b/edx_name_affirmation/signals.py
@@ -1,0 +1,7 @@
+"""
+Name Affirmation signals
+"""
+
+from django.dispatch import Signal
+
+VERIFIED_NAME_APPROVED = Signal(providing_args=['user_id', 'profile_name'])


### PR DESCRIPTION
**Description:**

Add a post save handler for VerifiedName that emits a signal with `user` and `profile_name` when its status changes to "approved".

**JIRA:**

[MST-803](https://openedx.atlassian.net/browse/MST-803)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
