### PR TITLE
feat: add state of feature toggle to API for general use

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[0.9.0] - 2021-09-01
+~~~~~~~~~~~~~~~~~~~~
+* Add is verified name enabled to the API
 * ADR for the use of signals in name affirmation service
 
 [0.8.2] - 2021-08-31

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.8.2'
+__version__ = '0.9.0'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/api.py
+++ b/edx_name_affirmation/api.py
@@ -4,6 +4,7 @@ Python API for edx_name_affirmation.
 
 import logging
 
+from edx_name_affirmation import toggles
 from edx_name_affirmation.exceptions import (
     VerifiedNameAttemptIdNotGiven,
     VerifiedNameDoesNotExist,
@@ -14,6 +15,16 @@ from edx_name_affirmation.models import VerifiedName, VerifiedNameConfig
 from edx_name_affirmation.statuses import VerifiedNameStatus
 
 log = logging.getLogger(__name__)
+
+
+def is_verified_name_enabled():
+    """
+    For callers with direct toggle import to ask if the verified name feature is enabled.
+
+    Since this uses edx_toggles it expects to be called
+    while servicing a request and will check the cached results.
+    """
+    return toggles.is_verified_name_enabled()
 
 
 def create_verified_name(

--- a/edx_name_affirmation/api.py
+++ b/edx_name_affirmation/api.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 def is_verified_name_enabled():
     """
-    For callers with direct toggle import to ask if the verified name feature is enabled.
+    For callers without direct toggle import available to ask if the verified name feature is enabled.
 
     Since this uses edx_toggles it expects to be called
     while servicing a request and will check the cached results.

--- a/edx_name_affirmation/tests/test_api.py
+++ b/edx_name_affirmation/tests/test_api.py
@@ -3,6 +3,7 @@ Tests for the `edx_name_affirmation` Python API.
 """
 
 import ddt
+from edx_toggles.toggles.testutils import override_waffle_flag
 
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
@@ -13,6 +14,7 @@ from edx_name_affirmation.api import (
     create_verified_name_config,
     get_verified_name,
     get_verified_name_history,
+    is_verified_name_enabled,
     should_use_verified_name_for_certs,
     update_verification_attempt_id,
     update_verified_name_status
@@ -25,6 +27,7 @@ from edx_name_affirmation.exceptions import (
 )
 from edx_name_affirmation.models import VerifiedName, VerifiedNameConfig
 from edx_name_affirmation.statuses import VerifiedNameStatus
+from edx_name_affirmation.toggles import VERIFIED_NAME_FLAG
 
 User = get_user_model()
 
@@ -311,3 +314,10 @@ class TestVerifiedNameAPI(TestCase):
         create_verified_name_config(self.user, use_verified_name_for_certs=True)
         create_verified_name_config(self.user)
         self.assertTrue(should_use_verified_name_for_certs(self.user))
+
+    def test_is_verified_name_enabled_false(self):
+        self.assertFalse(is_verified_name_enabled())
+
+    @override_waffle_flag(VERIFIED_NAME_FLAG, True)
+    def test_is_verified_name_enabled_true(self):
+        self.assertTrue(is_verified_name_enabled())


### PR DESCRIPTION
Exposes the toggle out via the api, everything in api is exposed via the service

MST-1020

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
