### PR TITLE
[MST-1025] Update IDV signal handler field names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.9.2] - 2021-09-07
+~~~~~~~~~~~~~~~~~~~~
+* Update IDV signal handler field names to be more explicit about the received names.
+
 [0.9.1] - 2021-09-07
 ~~~~~~~~~~~~~~~~~~~~
 * Add extra validation for the VerifiedName serializer, throwing a 400 error if

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.9.1'
+__version__ = '0.9.2'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/handlers.py
+++ b/edx_name_affirmation/handlers.py
@@ -32,7 +32,7 @@ def verified_name_approved(sender, instance, **kwargs):  # pylint: disable=unuse
         )
 
 
-def idv_attempt_handler(attempt_id, user_id, status, full_name, profile_name, **kwargs):
+def idv_attempt_handler(attempt_id, user_id, status, photo_id_name, full_name, **kwargs):
     """
     Receiver for IDV attempt updates
 
@@ -40,14 +40,14 @@ def idv_attempt_handler(attempt_id, user_id, status, full_name, profile_name, **
         attempt_id(int): ID associated with the IDV attempt
         user_id(int): ID associated with the IDV attempt's user
         status(str): status in IDV language for the IDV attempt
-        full_name(str): name to be used as verified name
-        profile_name(str): user's current profile name
+        photo_id_name(str): name to be used as verified name
+        full_name(str): user's pending name change or current profile name
     """
     if not is_verified_name_enabled():
         return
 
     trigger_status = VerifiedNameStatus.trigger_state_change_from_idv(status)
-    verified_names = VerifiedName.objects.filter(user__id=user_id, verified_name=full_name).order_by('-created')
+    verified_names = VerifiedName.objects.filter(user__id=user_id, verified_name=photo_id_name).order_by('-created')
     if verified_names:
         # if there are VerifiedName objects, we want to update existing entries
         # for each attempt with no attempt id (either proctoring or idv), update attempt id
@@ -89,8 +89,8 @@ def idv_attempt_handler(attempt_id, user_id, status, full_name, profile_name, **
         user = User.objects.get(id=user_id)
         verified_name = VerifiedName.objects.create(
             user=user,
-            verified_name=full_name,
-            profile_name=profile_name,
+            verified_name=photo_id_name,
+            profile_name=full_name,
             verification_attempt_id=attempt_id,
             status=(trigger_status if trigger_status else VerifiedNameStatus.PENDING),
         )


### PR DESCRIPTION
**Description:**

Update `full_name` -> `photo_id_name` and `profile_name` -> `full_name`, in order to be clearer that:

- `photo_id_name` is what's sent to the IDV provider (and therefore used as the verified name)
- `full_name` may not necessarily be the user's current profile name, but instead a pending name change

**JIRA:**

[MST-1025](https://openedx.atlassian.net/browse/MST-1025)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
