### PR TITLE
feat: endpoint exposing the API's verified name enabled flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.10.0] - 2021-09-13
+~~~~~~~~~~~~~~~~~~~~~
+* Add is verified name enabled endpoint
+
 [0.9.2] - 2021-09-07
 ~~~~~~~~~~~~~~~~~~~~
 * Update IDV signal handler field names to be more explicit about the received names.

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '0.9.2'
+__version__ = '0.10.0'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/tests/test_views.py
+++ b/edx_name_affirmation/tests/test_views.py
@@ -42,6 +42,21 @@ class NameAffirmationViewsTestCase(LoggedInTestCase):
 
 
 @ddt.ddt
+class VerifiedNameEnabledViewTests(NameAffirmationViewsTestCase):
+    """
+    Tests for the VerifiedNameEnabledView
+    """
+
+    @ddt.data(True, False)
+    def test_verified_name_feature_enabled(self, flag_state):
+        with override_waffle_flag(VERIFIED_NAME_FLAG, active=flag_state):
+            response = self.client.get(reverse('edx_name_affirmation:verified_name_enabled'))
+            self.assertEqual(response.status_code, 200)
+            data = json.loads(response.content.decode('utf-8'))
+            self.assertEqual(data, {"verified_name_enabled": flag_state})
+
+
+@ddt.ddt
 class VerifiedNameViewTests(NameAffirmationViewsTestCase):
     """
     Tests for the VerifiedNameView

--- a/edx_name_affirmation/urls.py
+++ b/edx_name_affirmation/urls.py
@@ -15,6 +15,12 @@ urlpatterns = [
     ),
 
     url(
+        r'edx_name_affirmation/v1/verified_name_enabled$',
+        views.VerifiedNameEnabledView.as_view(),
+        name='verified_name_enabled'
+    ),
+
+    url(
         r'edx_name_affirmation/v1/verified_name/history$',
         views.VerifiedNameHistoryView.as_view(),
         name='verified_name_history'

--- a/edx_name_affirmation/views.py
+++ b/edx_name_affirmation/views.py
@@ -16,12 +16,12 @@ from edx_name_affirmation.api import (
     create_verified_name_config,
     get_verified_name,
     get_verified_name_history,
+    is_verified_name_enabled,
     should_use_verified_name_for_certs
 )
 from edx_name_affirmation.exceptions import VerifiedNameMultipleAttemptIds
 from edx_name_affirmation.serializers import VerifiedNameConfigSerializer, VerifiedNameSerializer
 from edx_name_affirmation.statuses import VerifiedNameStatus
-from edx_name_affirmation.toggles import is_verified_name_enabled
 
 
 class AuthenticatedAPIView(APIView):
@@ -30,6 +30,27 @@ class AuthenticatedAPIView(APIView):
     """
     authentication_classes = (SessionAuthentication, JwtAuthentication)
     permission_classes = (IsAuthenticated,)
+
+
+class VerifiedNameEnabledView(AuthenticatedAPIView):
+    """
+    Endpoint for the UI to determine if this feature is on
+    /edx_name_affirmation/v1/verified_name_enabled
+
+    Supports:
+        HTTP GET: Returns True or False
+
+    HTTP GET
+        Example response: {
+            "verified_name_enabled": True
+        }
+    """
+    def get(self, request):
+        """
+        Get the state of the verified name enabled flag
+        """
+        flag = {'verified_name_enabled': is_verified_name_enabled()}
+        return Response(flag)
 
 
 class VerifiedNameView(AuthenticatedAPIView):


### PR DESCRIPTION
We provide the enabled flag with the verified name object if it exists or the history. For this particular use we don't need the full history but the verified name object may 404, so we need a separate flag endpoint.

Also connects the other use of this flag in the views to the API function rather than the toggle function for consistency.

[MST-1026](https://openedx.atlassian.net/browse/MST-1026)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
