### PR TITLE
fix: move toggle check out of task

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.0.1] - 2021-09-28
+~~~~~~~~~~~~~~~~~~~~~
+* Move toggle check out of tasks
+
 [1.0.0] - 2021-09-23
 ~~~~~~~~~~~~~~~~~~~~~
 * Move signal receiver logic into celery task

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/handlers.py
+++ b/edx_name_affirmation/handlers.py
@@ -12,6 +12,7 @@ from edx_name_affirmation.models import VerifiedName
 from edx_name_affirmation.signals import VERIFIED_NAME_APPROVED
 from edx_name_affirmation.statuses import VerifiedNameStatus
 from edx_name_affirmation.tasks import idv_update_verified_name, proctoring_update_verified_name
+from edx_name_affirmation.toggles import is_verified_name_enabled
 
 User = get_user_model()
 
@@ -42,7 +43,8 @@ def idv_attempt_handler(attempt_id, user_id, status, photo_id_name, full_name, *
         photo_id_name(str): name to be used as verified name
         full_name(str): user's pending name change or current profile name
     """
-    idv_update_verified_name.delay(attempt_id, user_id, status, photo_id_name, full_name)
+    if is_verified_name_enabled():
+        idv_update_verified_name.delay(attempt_id, user_id, status, photo_id_name, full_name)
 
 
 def proctoring_attempt_handler(
@@ -69,13 +71,14 @@ def proctoring_attempt_handler(
         is_proctored(boolean): if the exam attempt is for a proctored exam
         backend_supports_onboarding(boolean): if the exam attempt is for an exam with a backend that supports onboarding
     """
-    proctoring_update_verified_name.delay(
-        attempt_id,
-        user_id,
-        status,
-        full_name,
-        profile_name,
-        is_practice_exam,
-        is_proctored,
-        backend_supports_onboarding
-    )
+    if is_verified_name_enabled():
+        proctoring_update_verified_name.delay(
+            attempt_id,
+            user_id,
+            status,
+            full_name,
+            profile_name,
+            is_practice_exam,
+            is_proctored,
+            backend_supports_onboarding
+        )

--- a/edx_name_affirmation/tasks.py
+++ b/edx_name_affirmation/tasks.py
@@ -12,7 +12,6 @@ from django.contrib.auth import get_user_model
 
 from edx_name_affirmation.models import VerifiedName
 from edx_name_affirmation.statuses import VerifiedNameStatus
-from edx_name_affirmation.toggles import is_verified_name_enabled
 
 User = get_user_model()
 
@@ -25,8 +24,6 @@ def idv_update_verified_name(attempt_id, user_id, status, photo_id_name, full_na
     """
     Celery task for updating a verified name based on an IDV attempt
     """
-    if not is_verified_name_enabled():
-        return
 
     trigger_status = VerifiedNameStatus.trigger_state_change_from_idv(status)
     verified_names = VerifiedName.objects.filter(user__id=user_id, verified_name=photo_id_name).order_by('-created')
@@ -102,8 +99,6 @@ def proctoring_update_verified_name(
     """
     Celery task for updating a verified name based on a proctoring attempt
     """
-    if not is_verified_name_enabled():
-        return
 
     # We only care about updates from onboarding exams, or from non-practice proctored exams with a backend that
     # does not support onboarding. This is because those two event types are guaranteed to contain verification events,


### PR DESCRIPTION
The task is detached from the request context, so it can only pick up flags set for everyone, not flags set for a user or class of users. Since the task immediately exits on toggle fail, we can just not start it on toggle fail.

Existing tests already test the flag both on and off. There doesn't seem to be a standard way to run a task as a user which may be for the best anyway and there is no need to pass arguments or the user here for anything fancy because of the way the tasks work.

**JIRA:**

[MST-1063](https://openedx.atlassian.net/browse/MST-1063)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [ ] Described your changes in `CHANGELOG.rst`.
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
