### PR TITLE
[MST-1071] Add retry logic to celery tasks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.0.2] - 2021-09-29
+~~~~~~~~~~~~~~~~~~~~~
+* Add automatic retry logic to celery tasks.
+
 [1.0.1] - 2021-09-28
 ~~~~~~~~~~~~~~~~~~~~~
 * Move toggle check out of tasks

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/tests/test_tasks.py
+++ b/edx_name_affirmation/tests/test_tasks.py
@@ -1,0 +1,56 @@
+"""
+Tests for Name Affirmation tasks
+"""
+
+from mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from edx_name_affirmation.models import VerifiedName
+from edx_name_affirmation.statuses import VerifiedNameStatus
+from edx_name_affirmation.tasks import idv_update_verified_name, proctoring_update_verified_name
+
+User = get_user_model()
+
+
+class TaskTests(TestCase):
+    """
+    Tests for tasks.py
+    """
+    def setUp(self):  # pylint: disable=super-method-not-called
+        self.user = User(username='tester', email='tester@test.com')
+        self.user.save()
+        self.verified_name_obj = VerifiedName(
+          user=self.user, verified_name='Jonathan Doe', profile_name='Jon Doe',
+        )
+        self.verified_name_obj.save()
+        self.idv_attempt_id = 1111111
+        self.proctoring_attempt_id = 2222222
+
+    @patch('edx_name_affirmation.tasks.idv_update_verified_name.retry')
+    def test_idv_retry(self, mock_retry):
+        idv_update_verified_name.delay(
+            self.idv_attempt_id,
+            # force an error with an invalid user ID
+            99999,
+            VerifiedNameStatus.SUBMITTED,
+            self.verified_name_obj.verified_name,
+            self.verified_name_obj.profile_name,
+        )
+        mock_retry.assert_called()
+
+    @patch('edx_name_affirmation.tasks.proctoring_update_verified_name.retry')
+    def test_proctoring_retry(self, mock_retry):
+        proctoring_update_verified_name.delay(
+            self.proctoring_attempt_id,
+            # force an error with an invalid user ID
+            99999,
+            VerifiedNameStatus.PENDING,
+            self.verified_name_obj.verified_name,
+            self.verified_name_obj.profile_name,
+            True,
+            True,
+            True,
+        )
+        mock_retry.assert_called()


### PR DESCRIPTION
**Description:**

Set the IDV and proctoring celery tasks to retry up to 3 times with any exception. We can refine this later if we notice any patterns.

**JIRA:**

[MST-1071](https://openedx.atlassian.net/browse/MST-1071)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
