### PR TITLE
fix: reduce number of celery tasks for idv and proctoring updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.0.1] - 2021-11-15
+~~~~~~~~~~~~~~~~~~~~
+* If we receive a non-relevant status for either IDV or proctoring, do not
+  trigger a celery task.
+
 [2.0.0] - 2021-10-27
 ~~~~~~~~~~~~~~~~~~~~~
 * Remove VERIFIED_NAME_FLAG and all references to it.

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/tasks.py
+++ b/edx_name_affirmation/tasks.py
@@ -100,6 +100,79 @@ def idv_update_verified_name(self, attempt_id, user_id, status, photo_id_name, f
     bind=True, autoretry_for=(Exception,), default_retry_delay=DEFAULT_RETRY_SECONDS, max_retries=MAX_RETRIES,
 )
 @set_code_owner_attribute
+def idv_update_verified_name_task(self, attempt_id, user_id, name_affirmation_status, photo_id_name, full_name):
+    """
+    Celery task for updating a verified name based on an IDV attempt
+    """
+    log.info('VerifiedName: idv_update_verified_name triggering Celery task started for user %(user_id)s '
+             'with attempt_id %(attempt_id)s and status %(status)s',
+             {
+                'user_id': user_id,
+                'attempt_id': attempt_id,
+                'status': name_affirmation_status
+             }
+             )
+    verified_names = VerifiedName.objects.filter(user__id=user_id, verified_name=photo_id_name).order_by('-created')
+    if verified_names:
+        # if there are VerifiedName objects, we want to update existing entries
+        # for each attempt with no attempt id (either proctoring or idv), update attempt id
+        updated_for_attempt_id = verified_names.filter(
+            proctored_exam_attempt_id=None,
+            verification_attempt_id=None
+        ).update(verification_attempt_id=attempt_id)
+
+        if updated_for_attempt_id:
+            log.info(
+                'Updated VerifiedNames for user={user_id} to verification_attempt_id={attempt_id}'.format(
+                    user_id=user_id,
+                    attempt_id=attempt_id,
+                )
+            )
+
+        # then for all matching attempt ids, update the status
+        verified_name_qs = verified_names.filter(
+            verification_attempt_id=attempt_id,
+            proctored_exam_attempt_id=None
+        )
+
+        # Individually update to ensure that post_save signals send
+        for verified_name_obj in verified_name_qs:
+            verified_name_obj.status = name_affirmation_status
+            verified_name_obj.save()
+
+        log.info(
+            'Updated VerifiedNames for user={user_id} with verification_attempt_id={attempt_id} to '
+            'have status={status}'.format(
+                user_id=user_id,
+                attempt_id=attempt_id,
+                status=name_affirmation_status
+            )
+        )
+    else:
+        # otherwise if there are no entries, we want to create one.
+        user = User.objects.get(id=user_id)
+        verified_name = VerifiedName.objects.create(
+            user=user,
+            verified_name=photo_id_name,
+            profile_name=full_name,
+            verification_attempt_id=attempt_id,
+            status=name_affirmation_status,
+        )
+        log.error(
+            'Created VerifiedName for user={user_id} to have status={status} '
+            'and verification_attempt_id={attempt_id}, because no matching '
+            'attempt_id or verified_name were found.'.format(
+                user_id=user_id,
+                attempt_id=attempt_id,
+                status=verified_name.status
+            )
+        )
+
+
+@shared_task(
+    bind=True, autoretry_for=(Exception,), default_retry_delay=DEFAULT_RETRY_SECONDS, max_retries=MAX_RETRIES,
+)
+@set_code_owner_attribute
 def proctoring_update_verified_name(
     self,
     attempt_id,
@@ -177,6 +250,84 @@ def proctoring_update_verified_name(
                     user_id=user_id,
                     attempt_id=attempt_id,
                     status=trigger_status
+                )
+            )
+        else:
+            log.error(
+                'Cannot create VerifiedName for user={user_id} for proctored_exam_attempt_id={attempt_id} '
+                'because neither profile name nor full name were provided'.format(
+                    user_id=user_id,
+                    attempt_id=attempt_id,
+                )
+            )
+
+
+@shared_task(
+    bind=True, autoretry_for=(Exception,), default_retry_delay=DEFAULT_RETRY_SECONDS, max_retries=MAX_RETRIES,
+)
+@set_code_owner_attribute
+def proctoring_update_verified_name_task(
+    self,
+    attempt_id,
+    user_id,
+    name_affirmation_status,
+    full_name,
+    profile_name
+):
+    """
+    Celery task for updating a verified name based on a proctoring attempt
+    """
+
+    # check if approved VerifiedName already exists for the user
+    verified_name = VerifiedName.objects.filter(
+        user__id=user_id,
+        status=VerifiedNameStatus.APPROVED
+    ).order_by('-created').first()
+    if verified_name:
+        approved_verified_name = verified_name.verified_name
+        is_full_name_approved = approved_verified_name == full_name
+        if not is_full_name_approved:
+            log.warning(
+                'Full name for proctored_exam_attempt_id={attempt_id} is not equal '
+                'to the most recent verified name verified_name_id={name_id}.'.format(
+                    attempt_id=attempt_id,
+                    name_id=verified_name.id
+                )
+            )
+        return
+
+    verified_name = VerifiedName.objects.filter(
+        user__id=user_id,
+        proctored_exam_attempt_id=attempt_id
+    ).order_by('-created').first()
+    if verified_name:
+        verified_name.status = name_affirmation_status
+        verified_name.save()
+        log.info(
+            'Updated VerifiedName for user={user_id} with proctored_exam_attempt_id={attempt_id} '
+            'to have status={status}'.format(
+                user_id=user_id,
+                attempt_id=attempt_id,
+                status=name_affirmation_status
+            )
+        )
+    else:
+        if full_name and profile_name:
+            # if they do not already have an approved VerifiedName, create one
+            user = User.objects.get(id=user_id)
+            VerifiedName.objects.create(
+                user=user,
+                verified_name=full_name,
+                proctored_exam_attempt_id=attempt_id,
+                status=name_affirmation_status,
+                profile_name=profile_name
+            )
+            log.info(
+                'Created VerifiedName for user={user_id} to have status={status} '
+                'and proctored_exam_attempt_id={attempt_id}'.format(
+                    user_id=user_id,
+                    attempt_id=attempt_id,
+                    status=name_affirmation_status
                 )
             )
         else:


### PR DESCRIPTION
**Description:**

If we receive a non-relevant status for either an IDV or proctoring update, we should not trigger a celery task. This change means that if a non-relevant status is included in the first event name affirmation receives, no verified name will be created. This should not be an issue, as other signals that include a relevant status will eventually be captured.  

I've also added two new tasks that we can cut over to after this PR is merged. 

**JIRA:**

[MST-1145](https://openedx.atlassian.net/browse/MST-1145)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
