### PR TITLE
feat: cut over to new name affirmation tasks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.0.2] - 2021-11-16
+~~~~~~~~~~~~~~~~~~~~
+* Cut over to new celery tasks for IDV and proctoring handlers.
+
 [2.0.1] - 2021-11-15
 ~~~~~~~~~~~~~~~~~~~~
 * If we receive a non-relevant status for either IDV or proctoring, do not

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/handlers.py
+++ b/edx_name_affirmation/handlers.py
@@ -11,7 +11,7 @@ from django.dispatch.dispatcher import receiver
 from edx_name_affirmation.models import VerifiedName
 from edx_name_affirmation.signals import VERIFIED_NAME_APPROVED
 from edx_name_affirmation.statuses import VerifiedNameStatus
-from edx_name_affirmation.tasks import idv_update_verified_name, proctoring_update_verified_name
+from edx_name_affirmation.tasks import idv_update_verified_name_task, proctoring_update_verified_name_task
 
 User = get_user_model()
 
@@ -54,7 +54,7 @@ def idv_attempt_handler(attempt_id, user_id, status, photo_id_name, full_name, *
                      'status': status
                  }
                  )
-        idv_update_verified_name.delay(attempt_id, user_id, status, photo_id_name, full_name)
+        idv_update_verified_name_task.delay(attempt_id, user_id, trigger_status, photo_id_name, full_name)
     else:
         log.info('VerifiedName: idv_attempt_handler will not trigger Celery task for user %(user_id)s '
                  'with photo_id_name %(photo_id_name)s because of status %(status)s',
@@ -103,15 +103,12 @@ def proctoring_attempt_handler(
 
     # only trigger celery task if status is relevant to name affirmation
     if trigger_status:
-        proctoring_update_verified_name.delay(
+        proctoring_update_verified_name_task.delay(
             attempt_id,
             user_id,
-            status,
+            trigger_status,
             full_name,
             profile_name,
-            is_practice_exam,
-            is_proctored,
-            backend_supports_onboarding
         )
     else:
         log.info('VerifiedName: proctoring_attempt_handler will not trigger Celery task for user %(user_id)s '

--- a/edx_name_affirmation/tests/test_tasks.py
+++ b/edx_name_affirmation/tests/test_tasks.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 
 from edx_name_affirmation.models import VerifiedName
 from edx_name_affirmation.statuses import VerifiedNameStatus
-from edx_name_affirmation.tasks import idv_update_verified_name, proctoring_update_verified_name
+from edx_name_affirmation.tasks import idv_update_verified_name_task, proctoring_update_verified_name_task
 
 User = get_user_model()
 
@@ -28,9 +28,9 @@ class TaskTests(TestCase):
         self.idv_attempt_id = 1111111
         self.proctoring_attempt_id = 2222222
 
-    @patch('edx_name_affirmation.tasks.idv_update_verified_name.retry')
+    @patch('edx_name_affirmation.tasks.idv_update_verified_name_task.retry')
     def test_idv_retry(self, mock_retry):
-        idv_update_verified_name.delay(
+        idv_update_verified_name_task.delay(
             self.idv_attempt_id,
             # force an error with an invalid user ID
             99999,
@@ -40,17 +40,14 @@ class TaskTests(TestCase):
         )
         mock_retry.assert_called()
 
-    @patch('edx_name_affirmation.tasks.proctoring_update_verified_name.retry')
+    @patch('edx_name_affirmation.tasks.proctoring_update_verified_name_task.retry')
     def test_proctoring_retry(self, mock_retry):
-        proctoring_update_verified_name.delay(
+        proctoring_update_verified_name_task.delay(
             self.proctoring_attempt_id,
             # force an error with an invalid user ID
             99999,
             VerifiedNameStatus.PENDING,
             self.verified_name_obj.verified_name,
             self.verified_name_obj.profile_name,
-            True,
-            True,
-            True,
         )
         mock_retry.assert_called()


### PR DESCRIPTION
**Description:**

Now that the new name affirmation tasks have been registered, we should cut over to them. The old tasks will still remain in place to allow any remaining celery tasks in the queue to complete successfully. After that, we can remove the old tasks completely.

Won't merge until https://github.com/edx/edx-platform/pull/29333 is deployed.

**JIRA:**

[MST-1145](https://openedx.atlassian.net/browse/MST-1145)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [x] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
