### PR TITLE
Fix requirements update

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,21 +4,23 @@
 #
 #    make upgrade
 #
-amqp==5.0.6
+amqp==5.0.7
     # via kombu
+asgiref==3.4.1
+    # via django
 billiard==3.6.4.0
     # via celery
-celery==5.1.2
+celery==5.2.1
     # via
     #   -c requirements/constraints.txt
     #   edx-celeryutils
 certifi==2021.10.8
     # via requests
-cffi==1.14.6
+cffi==1.15.0
     # via cryptography
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via requests
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/constraints.txt
     #   celery
@@ -34,9 +36,9 @@ click-repl==0.2.0
     # via celery
 code-annotations==1.2.0
     # via edx-toggles
-cryptography==35.0.0
+cryptography==36.0.1
     # via pyjwt
-django==2.2.24
+django==3.2.10
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -56,7 +58,7 @@ django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-toggles
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/base.in
     #   edx-celeryutils
@@ -65,16 +67,14 @@ django-waffle==2.2.1
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.in
     #   django-config-models
     #   drf-jwt
     #   edx-drf-extensions
-drf-jwt==1.19.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   edx-drf-extensions
+drf-jwt==1.19.1
+    # via edx-drf-extensions
 edx-celeryutils==1.1.1
     # via -r requirements/base.in
 edx-django-utils==4.4.0
@@ -83,7 +83,7 @@ edx-django-utils==4.4.0
     #   django-config-models
     #   edx-drf-extensions
     #   edx-toggles
-edx-drf-extensions==8.0.0
+edx-drf-extensions==8.0.1
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via edx-drf-extensions
@@ -95,33 +95,33 @@ future==0.18.2
     #   pyjwkest
 idna==3.3
     # via requests
-jinja2==3.0.2
+jinja2==3.0.3
     # via code-annotations
 jsonfield==3.1.0
     # via edx-celeryutils
-kombu==5.1.0
+kombu==5.2.2
     # via celery
 markupsafe==2.0.1
     # via jinja2
-newrelic==7.2.1.168
+newrelic==7.2.4.171
     # via edx-django-utils
-pbr==5.6.0
+pbr==5.8.0
     # via stevedore
-prompt-toolkit==3.0.20
+prompt-toolkit==3.0.24
     # via click-repl
 psutil==5.8.0
     # via edx-django-utils
-pycparser==2.20
+pycparser==2.21
     # via cffi
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.2.0
+pyjwt[crypto]==2.3.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
-pymongo==3.12.0
+pymongo==4.0.1
     # via edx-opaque-keys
 python-dateutil==2.8.2
     # via edx-drf-extensions
@@ -131,7 +131,8 @@ pytz==2021.3
     # via
     #   celery
     #   django
-pyyaml==5.4.1
+    #   djangorestframework
+pyyaml==6.0
     # via code-annotations
 requests==2.26.0
     # via
@@ -147,7 +148,7 @@ six==1.16.0
     #   python-dateutil
 sqlparse==0.4.2
     # via django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   code-annotations
     #   edx-django-utils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-amqp==5.0.7
+amqp==5.0.9
     # via kombu
 asgiref==3.4.1
     # via django
@@ -22,7 +22,6 @@ charset-normalizer==2.0.9
     # via requests
 click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -77,7 +76,7 @@ drf-jwt==1.19.1
     # via edx-drf-extensions
 edx-celeryutils==1.1.1
     # via -r requirements/base.in
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -r requirements/base.in
     #   django-config-models

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,4 +1,4 @@
-amqp==5.0.7
+amqp==5.0.9
 billiard==3.6.4.0
 celery==5.2.1
 click==8.0.3

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,9 +1,9 @@
-amqp==5.0.6
+amqp==5.0.7
 billiard==3.6.4.0
-celery==5.1.2
-click==7.1.2
+celery==5.2.1
+click==8.0.3
 click-didyoumean==0.3.0
 click-repl==0.2.0
-kombu==5.1.0
-prompt-toolkit==3.0.20
+kombu==5.2.2
+prompt-toolkit==3.0.24
 vine==5.0.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,25 +4,25 @@
 #
 #    make upgrade
 #
-backports.entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.1
     # via virtualenv
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.0.2
+coverage==6.2
     # via codecov
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.3.0
+filelock==3.4.0
     # via
     #   tox
     #   virtualenv
 idna==3.3
     # via requests
-packaging==21.0
+packaging==21.3
     # via tox
 platformdirs==2.4.0
     # via virtualenv
@@ -30,9 +30,9 @@ pluggy==0.13.1
     # via
     #   -c requirements/constraints.txt
     #   tox
-py==1.10.0
+py==1.11.0
     # via tox
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 requests==2.26.0
     # via codecov
@@ -50,5 +50,5 @@ tox-battery==0.6.1
     # via -r requirements/ci.in
 urllib3==1.26.7
     # via requests
-virtualenv==20.8.1
+virtualenv==20.10.0
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,4 +15,3 @@ pluggy<=0.13.1          # diff-cover, tox, and pytest are creating version confl
 
 # pinning celery to latest release
 celery<6.0
-click<9.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,4 +15,4 @@ pluggy<=0.13.1          # diff-cover, tox, and pytest are creating version confl
 
 # pinning celery to latest release
 celery<6.0
-click<8.0.0
+click<9.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,7 +35,6 @@ charset-normalizer==2.0.9
     #   requests
 click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   click-log
@@ -90,7 +89,7 @@ idna==3.3
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==4.9.0
+importlib-metadata==4.10.0
     # via
     #   -r requirements/quality.txt
     #   keyring

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,12 +4,16 @@
 #
 #    make upgrade
 #
-astroid==2.8.2
+asgiref==3.4.1
+    # via
+    #   -r requirements/quality.txt
+    #   django
+astroid==2.9.0
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-backports.entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.1
     # via
     #   -r requirements/ci.txt
     #   virtualenv
@@ -22,18 +26,14 @@ certifi==2021.10.8
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-cffi==1.14.6
-    # via
-    #   -r requirements/quality.txt
-    #   cryptography
 chardet==4.0.0
     # via diff-cover
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/pip-tools.txt
@@ -56,35 +56,31 @@ colorama==0.4.4
     # via
     #   -r requirements/quality.txt
     #   twine
-coverage==6.0.2
+coverage==6.2
     # via
     #   -r requirements/ci.txt
     #   codecov
-cryptography==35.0.0
-    # via
-    #   -r requirements/quality.txt
-    #   secretstorage
-diff-cover==6.4.2
+diff-cover==6.4.4
     # via -r requirements/dev.in
-distlib==0.3.3
+distlib==0.3.4
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==2.2.24
+django==3.2.10
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   edx-i18n-tools
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
     #   rstcheck
 edx-i18n-tools==0.8.1
     # via -r requirements/dev.in
-edx-lint==5.2.0
+edx-lint==5.2.1
     # via -r requirements/quality.txt
-filelock==3.3.0
+filelock==3.4.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -94,35 +90,25 @@ idna==3.3
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==4.8.1
+importlib-metadata==4.9.0
     # via
     #   -r requirements/quality.txt
     #   keyring
     #   twine
-inflect==5.3.0
-    # via jinja2-pluralize
-isort==5.9.3
+isort==5.10.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-jeepney==0.7.1
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
-    #   jinja2-pluralize
-jinja2-pluralize==0.3.0
-    # via diff-cover
-keyring==23.2.1
+keyring==23.4.0
     # via
     #   -r requirements/quality.txt
     #   twine
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via
     #   -r requirements/quality.txt
     #   astroid
@@ -134,7 +120,7 @@ mccabe==0.6.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-packaging==21.0
+packaging==21.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -142,17 +128,17 @@ packaging==21.0
     #   tox
 path==16.2.0
     # via edx-i18n-tools
-pbr==5.6.0
+pbr==5.8.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pep517==0.11.0
+pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
 pip-tools==6.4.0
     # via -r requirements/pip-tools.txt
-pkginfo==1.7.1
+pkginfo==1.8.2
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -170,16 +156,12 @@ pluggy==0.13.1
     #   tox
 polib==1.1.1
     # via edx-i18n-tools
-py==1.10.0
+py==1.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
 pycodestyle==2.8.0
     # via -r requirements/quality.txt
-pycparser==2.20
-    # via
-    #   -r requirements/quality.txt
-    #   cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.txt
 pygments==2.10.0
@@ -187,7 +169,7 @@ pygments==2.10.0
     #   -r requirements/quality.txt
     #   diff-cover
     #   readme-renderer
-pylint==2.11.1
+pylint==2.12.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -207,7 +189,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -220,12 +202,12 @@ pytz==2021.3
     # via
     #   -r requirements/quality.txt
     #   django
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
     #   edx-i18n-tools
-readme-renderer==30.0
+readme-renderer==32.0
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -246,10 +228,6 @@ rfc3986==1.5.0
     #   twine
 rstcheck==3.3.1
     # via -r requirements/quality.txt
-secretstorage==3.3.1
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 six==1.16.0
     # via
     #   -r requirements/ci.txt
@@ -258,7 +236,7 @@ six==1.16.0
     #   edx-lint
     #   tox
     #   virtualenv
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
@@ -266,7 +244,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/quality.txt
     #   django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -280,7 +258,7 @@ toml==0.10.2
     #   -r requirements/quality.txt
     #   pylint
     #   tox
-tomli==1.2.1
+tomli==2.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   pep517
@@ -296,9 +274,9 @@ tqdm==4.62.3
     # via
     #   -r requirements/quality.txt
     #   twine
-twine==3.4.2
+twine==3.7.1
     # via -r requirements/quality.txt
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via
     #   -r requirements/quality.txt
     #   astroid
@@ -308,7 +286,7 @@ urllib3==1.26.7
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-virtualenv==20.8.1
+virtualenv==20.10.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -320,7 +298,7 @@ wheel==0.37.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-wrapt==1.12.1
+wrapt==1.13.3
     # via
     #   -r requirements/quality.txt
     #   astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12
     # via sphinx
-amqp==5.0.7
+amqp==5.0.9
     # via kombu
 asgiref==3.4.1
     # via django
@@ -28,7 +28,6 @@ charset-normalizer==2.0.9
     # via requests
 click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -91,7 +90,7 @@ drf-jwt==1.19.1
     # via edx-drf-extensions
 edx-celeryutils==1.1.1
     # via -r requirements/base.in
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -191,7 +190,7 @@ six==1.16.0
     #   sphinxcontrib-napoleon
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.3.1
+sphinx==4.3.2
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,25 +6,27 @@
 #
 alabaster==0.7.12
     # via sphinx
-amqp==5.0.6
+amqp==5.0.7
     # via kombu
+asgiref==3.4.1
+    # via django
 babel==2.9.1
     # via sphinx
 billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via readme-renderer
-celery==5.1.2
+celery==5.2.1
     # via
     #   -c requirements/constraints.txt
     #   edx-celeryutils
 certifi==2021.10.8
     # via requests
-cffi==1.14.6
+cffi==1.15.0
     # via cryptography
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via requests
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/constraints.txt
     #   celery
@@ -40,9 +42,9 @@ click-repl==0.2.0
     # via celery
 code-annotations==1.2.0
     # via edx-toggles
-cryptography==35.0.0
+cryptography==36.0.1
     # via pyjwt
-django==2.2.24
+django==3.2.10
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -62,7 +64,7 @@ django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-toggles
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/base.in
     #   edx-celeryutils
@@ -71,13 +73,13 @@ django-waffle==2.2.1
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.in
     #   django-config-models
     #   drf-jwt
     #   edx-drf-extensions
-doc8==0.9.1
+doc8==0.10.1
     # via -r requirements/doc.in
 docutils==0.17.1
     # via
@@ -85,10 +87,8 @@ docutils==0.17.1
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-drf-jwt==1.19.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   edx-drf-extensions
+drf-jwt==1.19.1
+    # via edx-drf-extensions
 edx-celeryutils==1.1.1
     # via -r requirements/base.in
 edx-django-utils==4.4.0
@@ -97,7 +97,7 @@ edx-django-utils==4.4.0
     #   django-config-models
     #   edx-drf-extensions
     #   edx-toggles
-edx-drf-extensions==8.0.0
+edx-drf-extensions==8.0.1
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via edx-drf-extensions
@@ -111,35 +111,35 @@ future==0.18.2
     #   pyjwkest
 idna==3.3
     # via requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   code-annotations
     #   sphinx
 jsonfield==3.1.0
     # via edx-celeryutils
-kombu==5.1.0
+kombu==5.2.2
     # via celery
 markupsafe==2.0.1
     # via jinja2
-newrelic==7.2.1.168
+newrelic==7.2.4.171
     # via edx-django-utils
-packaging==21.0
+packaging==21.3
     # via
     #   bleach
     #   sphinx
-pbr==5.6.0
+pbr==5.8.0
     # via stevedore
 pockets==0.9.1
     # via sphinxcontrib-napoleon
-prompt-toolkit==3.0.20
+prompt-toolkit==3.0.24
     # via click-repl
 psutil==5.8.0
     # via edx-django-utils
-pycparser==2.20
+pycparser==2.21
     # via cffi
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via pyjwkest
 pygments==2.10.0
     # via
@@ -148,13 +148,13 @@ pygments==2.10.0
     #   sphinx
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.2.0
+pyjwt[crypto]==2.3.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
-pymongo==3.12.0
+pymongo==4.0.1
     # via edx-opaque-keys
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 python-dateutil==2.8.2
     # via edx-drf-extensions
@@ -165,9 +165,10 @@ pytz==2021.3
     #   babel
     #   celery
     #   django
-pyyaml==5.4.1
+    #   djangorestframework
+pyyaml==6.0
     # via code-annotations
-readme-renderer==30.0
+readme-renderer==32.0
     # via -r requirements/doc.in
 requests==2.26.0
     # via
@@ -188,9 +189,9 @@ six==1.16.0
     #   pyjwkest
     #   python-dateutil
     #   sphinxcontrib-napoleon
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.2.0
+sphinx==4.3.1
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -210,7 +211,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sqlparse==0.4.2
     # via django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   code-annotations
     #   doc8

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,9 +5,7 @@
 #    make upgrade
 #
 click==8.0.3
-    # via
-    #   -c requirements/constraints.txt
-    #   pip-tools
+    # via pip-tools
 pep517==0.12.0
     # via pip-tools
 pip-tools==6.4.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/constraints.txt
     #   pip-tools
-pep517==0.11.0
+pep517==0.12.0
     # via pip-tools
 pip-tools==6.4.0
     # via -r requirements/pip-tools.in
-tomli==1.2.1
+tomli==2.0.0
     # via pep517
 wheel==0.37.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -18,7 +18,6 @@ charset-normalizer==2.0.9
     # via requests
 click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   click-log
     #   code-annotations
     #   edx-lint
@@ -40,7 +39,7 @@ edx-lint==5.2.1
     # via -r requirements/quality.in
 idna==3.3
     # via requests
-importlib-metadata==4.9.0
+importlib-metadata==4.10.0
     # via
     #   keyring
     #   twine

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,9 @@
 #
 #    make upgrade
 #
-astroid==2.8.2
+asgiref==3.4.1
+    # via django
+astroid==2.9.0
     # via
     #   pylint
     #   pylint-celery
@@ -12,11 +14,9 @@ bleach==4.1.0
     # via readme-renderer
 certifi==2021.10.8
     # via requests
-cffi==1.14.6
-    # via cryptography
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via requests
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/constraints.txt
     #   click-log
@@ -28,59 +28,51 @@ code-annotations==1.2.0
     # via edx-lint
 colorama==0.4.4
     # via twine
-cryptography==35.0.0
-    # via secretstorage
-django==2.2.24
+django==3.2.10
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.in
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   readme-renderer
     #   rstcheck
-edx-lint==5.2.0
+edx-lint==5.2.1
     # via -r requirements/quality.in
 idna==3.3
     # via requests
-importlib-metadata==4.8.1
+importlib-metadata==4.9.0
     # via
     #   keyring
     #   twine
-isort==5.9.3
+isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
-jinja2==3.0.2
+jinja2==3.0.3
     # via code-annotations
-keyring==23.2.1
+keyring==23.4.0
     # via twine
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 markupsafe==2.0.1
     # via jinja2
 mccabe==0.6.1
     # via pylint
-packaging==21.0
+packaging==21.3
     # via bleach
-pbr==5.6.0
+pbr==5.8.0
     # via stevedore
-pkginfo==1.7.1
+pkginfo==1.8.2
     # via twine
 platformdirs==2.4.0
     # via pylint
 pycodestyle==2.8.0
     # via -r requirements/quality.in
-pycparser==2.20
-    # via cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.in
 pygments==2.10.0
     # via readme-renderer
-pylint==2.11.1
+pylint==2.12.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -94,15 +86,15 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 python-slugify==5.0.2
     # via code-annotations
 pytz==2021.3
     # via django
-pyyaml==5.4.1
+pyyaml==6.0
     # via code-annotations
-readme-renderer==30.0
+readme-renderer==32.0
     # via twine
 requests==2.26.0
     # via
@@ -114,17 +106,15 @@ rfc3986==1.5.0
     # via twine
 rstcheck==3.3.1
     # via -r requirements/quality.in
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   bleach
     #   edx-lint
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via pydocstyle
 sqlparse==0.4.2
     # via django
-stevedore==3.4.0
+stevedore==3.5.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
@@ -132,9 +122,9 @@ toml==0.10.2
     # via pylint
 tqdm==4.62.3
     # via twine
-twine==3.4.2
+twine==3.7.1
     # via -r requirements/quality.in
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via
     #   astroid
     #   pylint
@@ -142,7 +132,7 @@ urllib3==1.26.7
     # via requests
 webencodings==0.5.1
     # via bleach
-wrapt==1.12.1
+wrapt==1.13.3
     # via astroid
 zipp==3.6.0
     # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,6 +7,10 @@
     # via
     #   -r requirements/base.txt
     #   kombu
+asgiref==3.4.1
+    # via
+    #   -r requirements/base.txt
+    #   django
 attrs==21.2.0
     # via pytest
     # via
@@ -20,15 +24,15 @@ certifi==2021.10.8
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via
     #   -r requirements/base.txt
     #   requests
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -54,9 +58,9 @@ code-annotations==1.2.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-toggles
-coverage[toml]==6.0.2
+coverage[toml]==6.2
     # via pytest-cov
-cryptography==35.0.0
+cryptography==36.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -82,7 +86,7 @@ django-crum==0.7.9
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-toggles
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
@@ -92,15 +96,14 @@ django-waffle==2.2.1
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.txt
     #   django-config-models
     #   drf-jwt
     #   edx-drf-extensions
-drf-jwt==1.19.0
+drf-jwt==1.19.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-drf-extensions
 edx-celeryutils==1.1.1
@@ -111,7 +114,7 @@ edx-django-utils==4.4.0
     #   django-config-models
     #   edx-drf-extensions
     #   edx-toggles
-edx-drf-extensions==8.0.0
+edx-drf-extensions==8.0.1
     # via -r requirements/base.txt
 edx-opaque-keys==2.2.2
     # via
@@ -130,7 +133,7 @@ idna==3.3
     #   requests
 iniconfig==1.1.1
     # via pytest
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -147,13 +150,13 @@ markupsafe==2.0.1
     #   jinja2
 mock==4.0.3
     # via -r requirements/test.in
-newrelic==7.2.1.168
+newrelic==7.2.4.171
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-packaging==21.0
+packaging==21.3
     # via pytest
-pbr==5.6.0
+pbr==5.8.0
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -161,7 +164,7 @@ pluggy==0.13.1
     # via
     #   -c requirements/constraints.txt
     #   pytest
-prompt-toolkit==3.0.20
+prompt-toolkit==3.0.24
     # via
     #   -r requirements/base.txt
     #   click-repl
@@ -169,13 +172,13 @@ psutil==5.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-py==1.10.0
+py==1.11.0
     # via pytest
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -183,16 +186,16 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.2.0
+pyjwt[crypto]==2.3.0
     # via
     #   -r requirements/base.txt
     #   drf-jwt
     #   edx-drf-extensions
-pymongo==3.12.0
+pymongo==4.0.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pytest==6.2.5
     # via
@@ -200,7 +203,7 @@ pytest==6.2.5
     #   pytest-django
 pytest-cov==3.0.0
     # via -r requirements/test.in
-pytest-django==4.4.0
+pytest-django==4.5.2
     # via -r requirements/test.in
 python-dateutil==2.8.2
     # via
@@ -215,7 +218,8 @@ pytz==2021.3
     #   -r requirements/base.txt
     #   celery
     #   django
-pyyaml==5.4.1
+    #   djangorestframework
+pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -239,7 +243,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -251,7 +255,7 @@ text-unidecode==1.3
     #   python-slugify
 toml==0.10.2
     # via pytest
-tomli==1.2.1
+tomli==2.0.0
     # via coverage
 urllib3==1.26.7
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -34,7 +34,6 @@ charset-normalizer==2.0.9
     #   requests
 click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   celery
     #   click-didyoumean
@@ -108,7 +107,7 @@ drf-jwt==1.19.1
     #   edx-drf-extensions
 edx-celeryutils==1.1.1
     # via -r requirements/base.txt
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -r requirements/base.txt
     #   django-config-models

--- a/tox.ini
+++ b/tox.ini
@@ -83,6 +83,6 @@ commands =
 setenv =
     DJANGO_SETTINGS_MODULE = test_settings
 deps =
-    -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/quality.txt
 commands =
     code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage


### PR DESCRIPTION
**Description:**

1. Requirements had been failing due to a minor version celery release requiring a major version bump in click.
2. The pii job is broken as of the Django 4 release. Wait but there's a constraint file and we aren't even on 3.0 yet?! Yes, but it turns out there's a bit of a foot gun in here. Any constraints on the django version are scrubbed on test.txt with the expectation the default tox testenv would set it. Creating different environments for quality, pii_check, etc that use test.txt alone will just install the most recent version of django. 🤦  

There's probably a better tox/make refactor to avoid this trap, but this unblocks things at least for now.

@edx/masters-devs-cosmonauts 
