### PR TITLE
[MST-1275] Add `statuses_to_exclude` arg to `get_verified_name`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.1.0] - 2022-01-11
+~~~~~~~~~~~~~~~~~~~~
+* Add optional `statuses_to_exclude` argument to `get_verified_name` in order to filter out one or
+  more statuses from the result.
+
 [2.0.3] - 2021-11-17
 ~~~~~~~~~~~~~~~~~~~~
 * Remove unused celery tasks

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '2.0.3'
+__version__ = '2.1.0'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/api.py
+++ b/edx_name_affirmation/api.py
@@ -76,7 +76,7 @@ def create_verified_name(
     log.info(log_msg)
 
 
-def get_verified_name(user, is_verified=False):
+def get_verified_name(user, is_verified=False, statuses_to_exclude=None):
     """
     Get the most recent VerifiedName for a given user.
 
@@ -84,6 +84,8 @@ def get_verified_name(user, is_verified=False):
         * `user` (User object)
         * `is_verified` (bool): Optional, set to True to ignore entries that are not
           verified.
+        * `statuses_to_exclude` (list): Optional list of statuses to filter out. Only
+          relevant if `is_verified` is False.
 
     Returns a VerifiedName object.
     """
@@ -91,6 +93,9 @@ def get_verified_name(user, is_verified=False):
 
     if is_verified:
         return verified_name_qs.filter(status=VerifiedNameStatus.APPROVED.value).first()
+
+    if statuses_to_exclude:
+        return verified_name_qs.exclude(status__in=statuses_to_exclude).first()
 
     return verified_name_qs.first()
 


### PR DESCRIPTION
**Description:**

Add the ability to filter out a list of statuses when calling `get_verified_name`.

**JIRA:**

[MST-1275](https://openedx.atlassian.net/browse/MST-1275)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
