### PR TITLE
fix: allow error status updates to trigger verified name updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.2.1] - 2022-02-23
+~~~~~~~~~~~~~~~~~~~~
+* Update verified name status to `denied` if proctoring `error` status is received
+
 [2.2.0] - 2022-02-14
 ~~~~~~~~~~~~~~~~~~~~
 * Added Django40 testing and dropped Django22, 30 and 31 support

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/statuses.py
+++ b/edx_name_affirmation/statuses.py
@@ -59,7 +59,8 @@ class VerifiedNameStatus(str, Enum):
             'created': cls.PENDING,
             'submitted': cls.SUBMITTED,
             'verified': cls.APPROVED,
-            'rejected': cls.DENIED
+            'rejected': cls.DENIED,
+            'error': cls.DENIED,
         }
 
         return proctoring_state_transition_mapping.get(proctoring_status, None)


### PR DESCRIPTION
**Description:**

Students who take a proctored exam and receive an `error` status are blocked from making changes to their name. This is because name affirmation only triggers verified name updates based on certain proctored exam statuses (`error` was previously not one of the statuses that would trigger a verified name update). To allow learners the ability to change their name, we should handle `error` status updates from proctored exams.

**JIRA:**

[MST-1375](https://openedx.atlassian.net/browse/MST-1375)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [ ] Described your changes in `CHANGELOG.rst`.
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
