### PR TITLE
[MST-1361] Add patch and delete to VerifiedNameView

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.3.0] - 2022-02-28
+~~~~~~~~~~~~~~~~~~~~
+* Add REST API functionality to update verified name status, and to delete verified names.
+
 [2.2.1] - 2022-02-23
 ~~~~~~~~~~~~~~~~~~~~
 * Update verified name status to `denied` if proctoring `error` status is received

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '2.2.1'
+__version__ = '2.3.0'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/serializers.py
+++ b/edx_name_affirmation/serializers.py
@@ -29,7 +29,7 @@ class VerifiedNameSerializer(serializers.ModelSerializer):
         model = VerifiedName
 
         fields = (
-            "created", "username", "verified_name", "profile_name", "verification_attempt_id",
+            "id", "created", "username", "verified_name", "profile_name", "verification_attempt_id",
             "proctored_exam_attempt_id", "status"
         )
 
@@ -52,6 +52,16 @@ class VerifiedNameSerializer(serializers.ModelSerializer):
         """
         regex = re.findall(r'https|http?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+', string)
         return bool(regex)
+
+
+class UpdateVerifiedNameSerializer(VerifiedNameSerializer):
+    """
+    Serializer for updates to the VerifiedName Model.
+    """
+    username = serializers.CharField(source='user.username', required=True)
+    verified_name = serializers.CharField(required=False)
+    profile_name = serializers.CharField(required=False)
+    status = serializers.CharField(required=True)
 
 
 class VerifiedNameConfigSerializer(serializers.ModelSerializer):

--- a/edx_name_affirmation/urls.py
+++ b/edx_name_affirmation/urls.py
@@ -9,17 +9,25 @@ from edx_name_affirmation import views
 app_name = 'edx_name_affirmation'
 
 urlpatterns = [
-    path('edx_name_affirmation/v1/verified_name', views.VerifiedNameView.as_view(),
-         name='verified_name'
-         ),
+    path(
+        'edx_name_affirmation/v1/verified_name', views.VerifiedNameView.as_view(),
+        name='verified_name'
+    ),
 
-    path('edx_name_affirmation/v1/verified_name/history', views.VerifiedNameHistoryView.as_view(),
-         name='verified_name_history'
-         ),
+    path(
+        r'edx_name_affirmation/v1/verified_name/(?P<verified_name_id>\d+)$',
+        views.VerifiedNameView.as_view(), name='verified_name_by_id'
+    ),
 
-    path('edx_name_affirmation/v1/verified_name/config', views.VerifiedNameConfigView.as_view(),
-         name='verified_name_config'
-         ),
+    path(
+        'edx_name_affirmation/v1/verified_name/history', views.VerifiedNameHistoryView.as_view(),
+        name='verified_name_history'
+    ),
+
+    path(
+        'edx_name_affirmation/v1/verified_name/config', views.VerifiedNameConfigView.as_view(),
+        name='verified_name_config'
+    ),
 
     path('', include('rest_framework.urls', namespace='rest_framework')),
 ]


### PR DESCRIPTION
**Description:**

Add REST API functionality to update verified name status, and to delete verified names. Both require staff access.

**JIRA:**

[MST-1361](https://openedx.atlassian.net/browse/MST-1361)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
