### PR TITLE
feat: if a proctored exam or IDV attempt is deleted, we should delete the VerifiedName

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.3.1] - 2022-03-02
+~~~~~~~~~~~~~~~~~~~~
+* Add two signal handlers to capture post_delete signals from ProctoredExamStudentAttempt and SoftwareSecurePhotoVerification models.
+  If those signals are received, the corresponding VerifiedName(s), if it exists, will be deleted.
+
 [2.3.0] - 2022-02-28
 ~~~~~~~~~~~~~~~~~~~~
 * Add REST API functionality to update verified name status, and to delete verified names.

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/apps.py
+++ b/edx_name_affirmation/apps.py
@@ -29,9 +29,19 @@ class EdxNameAffirmationConfig(AppConfig):
                         'signal_path': 'lms.djangoapps.verify_student.signals.idv_update_signal',
                     },
                     {
+                        'receiver_func_name': 'idv_delete_handler',
+                        'signal_path': 'django.db.models.signals.post_delete',
+                        'sender_path': 'lms.djangoapps.verify_student.models.SoftwareSecurePhotoVerification',
+                    },
+                    {
                         'receiver_func_name': 'proctoring_attempt_handler',
                         'signal_path': 'edx_proctoring.signals.exam_attempt_status_signal',
-                    }
+                    },
+                    {
+                        'receiver_func_name': 'proctoring_delete_handler',
+                        'signal_path': 'django.db.models.signals.post_delete',
+                        'sender_path': 'edx_proctoring.models.ProctoredExamStudentAttempt',
+                    },
                 ],
             }
         }

--- a/edx_name_affirmation/tests/test_tasks.py
+++ b/edx_name_affirmation/tests/test_tasks.py
@@ -2,6 +2,7 @@
 Tests for Name Affirmation tasks
 """
 
+import ddt
 from mock import patch
 
 from django.contrib.auth import get_user_model
@@ -9,11 +10,16 @@ from django.test import TestCase
 
 from edx_name_affirmation.models import VerifiedName
 from edx_name_affirmation.statuses import VerifiedNameStatus
-from edx_name_affirmation.tasks import idv_update_verified_name_task, proctoring_update_verified_name_task
+from edx_name_affirmation.tasks import (
+    delete_verified_name_task,
+    idv_update_verified_name_task,
+    proctoring_update_verified_name_task
+)
 
 User = get_user_model()
 
 
+@ddt.ddt
 class TaskTests(TestCase):
     """
     Tests for tasks.py
@@ -51,3 +57,101 @@ class TaskTests(TestCase):
             self.verified_name_obj.profile_name,
         )
         mock_retry.assert_called()
+
+    def test_idv_delete(self):
+        """
+        Assert that only relevant VerifiedNames are deleted for a given idv_attempt_id
+        """
+        # associated test object with an idv attempt
+        self.verified_name_obj.verification_attempt_id = self.idv_attempt_id
+        self.verified_name_obj.save()
+
+        other_attempt_id = 123456
+
+        # create another VerifiedName with the same idv attempt
+        VerifiedName(
+            user=self.user,
+            verified_name='Jonathan X Doe',
+            profile_name='Jon D',
+            verification_attempt_id=self.idv_attempt_id
+        ).save()
+
+        # create VerifiedName not associated with idv attempt
+        other_verified_name_obj = VerifiedName(
+            user=self.user,
+            verified_name='Jonathan X Doe',
+            profile_name='Jon D',
+            verification_attempt_id=other_attempt_id
+        )
+        other_verified_name_obj.save()
+
+        delete_verified_name_task.delay(
+            self.idv_attempt_id,
+            None
+        )
+
+        # check that there is only VerifiedName object
+        self.assertEqual(len(VerifiedName.objects.filter(verification_attempt_id=self.idv_attempt_id)), 0)
+        self.assertEqual(len(VerifiedName.objects.filter(verification_attempt_id=other_attempt_id)), 1)
+
+    def test_proctoring_delete(self):
+        """
+        Assert that only relevant VerifiedNames are deleted for a given proctoring_attempt_id
+        """
+        # associated test object with a proctoring attempt
+        self.verified_name_obj.proctored_exam_attempt_id = self.proctoring_attempt_id
+        self.verified_name_obj.save()
+
+        other_attempt_id = 123456
+
+        # create another VerifiedName with the same proctoring attempt
+        VerifiedName(
+            user=self.user,
+            verified_name='Jonathan X Doe',
+            profile_name='Jon D',
+            proctored_exam_attempt_id=self.proctoring_attempt_id
+        ).save()
+
+        # create VerifiedName not associated with proctoring attempt
+        other_verified_name_obj = VerifiedName(
+            user=self.user,
+            verified_name='Jonathan X Doe',
+            profile_name='Jon D',
+            proctored_exam_attempt_id=other_attempt_id
+        )
+        other_verified_name_obj.save()
+
+        delete_verified_name_task.delay(
+            None,
+            self.proctoring_attempt_id
+        )
+
+        # check that there is only VerifiedName object
+        self.assertEqual(len(VerifiedName.objects.filter(proctored_exam_attempt_id=self.proctoring_attempt_id)), 0)
+        self.assertEqual(len(VerifiedName.objects.filter(proctored_exam_attempt_id=other_attempt_id)), 1)
+
+    @ddt.data(
+        (1234, 5678),
+        (None, None)
+    )
+    @ddt.unpack
+    @patch('logging.Logger.error')
+    def test_incorrect_args_delete(self, idv_attempt_id, proctoring_attempt_id, mock_logger):
+        """
+        Assert that error log is called and that no VerifiedNames are deleted when incorrect args are passed to task
+        """
+        delete_verified_name_task.delay(
+            idv_attempt_id,
+            proctoring_attempt_id
+        )
+        mock_logger.assert_called()
+
+    @patch('logging.Logger.info')
+    def test_no_names_delete(self, mock_logger):
+        delete_verified_name_task.delay(
+            self.idv_attempt_id,
+            None
+        )
+        mock_logger.assert_called_with(
+            'No VerifiedNames deleted because no VerifiedNames were associated with the provided attempt ID.'
+        )


### PR DESCRIPTION
**Description:**

If a proctored exam attempt or an IDV attempt are deleted, we should capture that `post_delete` signal to delete any VerifiedNames associated with the deleted attempt. 

Any `post_delete` signal will trigger a celery task, although I don't anticipate this causing too much noise. We've had ~1300 deleted proctoring attempts since 1/01/22 which averages to about 20 deletes a day.

**JIRA:**

[MST-1394](https://openedx.atlassian.net/browse/MST-1394)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [x] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
