### PR TITLE
rm pluggy constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 amqp==5.1.1
     # via kombu
-asgiref==3.5.0
+asgiref==3.5.1
     # via django
 billiard==3.6.4.0
     # via celery
@@ -20,7 +20,7 @@ cffi==1.15.0
     # via cryptography
 charset-normalizer==2.0.12
     # via requests
-click==8.1.2
+click==8.1.3
     # via
     #   celery
     #   click-didyoumean
@@ -41,7 +41,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==36.0.2
+cryptography==37.0.1
     # via pyjwt
 django==3.2.13
     # via
@@ -114,7 +114,7 @@ inflection==0.5.1
     # via drf-yasg
 itypes==1.2.0
     # via coreapi
-jinja2==3.1.1
+jinja2==3.1.2
     # via
     #   code-annotations
     #   coreschema
@@ -150,7 +150,7 @@ pyparsing==3.0.8
     # via packaging
 python-dateutil==2.8.2
     # via edx-drf-extensions
-python-slugify==6.1.1
+python-slugify==6.1.2
     # via code-annotations
 pytz==2022.1
     # via

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -10,7 +10,7 @@ billiard==3.6.4.0
     # via celery
 celery==5.2.6
     # via -r requirements/celery50.in
-click==8.1.2
+click==8.1.3
     # via
     #   celery
     #   click-didyoumean

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -24,10 +24,8 @@ packaging==21.3
     # via tox
 platformdirs==2.5.2
     # via virtualenv
-pluggy==0.13.1
-    # via
-    #   -c requirements/constraints.txt
-    #   tox
+pluggy==1.0.0
+    # via tox
 py==1.11.0
     # via tox
 pyparsing==3.0.8

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,7 +11,5 @@
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
-pluggy<=0.13.1          # diff-cover, tox, and pytest are creating version conflicts for pluggy, pinning to resolve
-
 # pinning celery to latest release
 celery<6.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -145,9 +145,8 @@ platformdirs==2.5.2
     #   -r requirements/quality.txt
     #   pylint
     #   virtualenv
-pluggy==0.13.1
+pluggy==1.0.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/ci.txt
     #   diff-cover
     #   tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.1
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.11.3
+astroid==2.11.4
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -22,10 +22,6 @@ certifi==2021.10.8
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-cffi==1.15.0
-    # via
-    #   -r requirements/quality.txt
-    #   cryptography
 chardet==4.0.0
     # via diff-cover
 charset-normalizer==2.0.12
@@ -33,7 +29,7 @@ charset-normalizer==2.0.12
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-click==8.1.2
+click==8.1.3
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -59,10 +55,6 @@ coverage==6.3.2
     # via
     #   -r requirements/ci.txt
     #   codecov
-cryptography==36.0.2
-    # via
-    #   -r requirements/quality.txt
-    #   secretstorage
 diff-cover==6.5.0
     # via -r requirements/dev.in
 dill==0.3.4
@@ -106,12 +98,7 @@ isort==5.10.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-jeepney==0.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
-jinja2==3.1.1
+jinja2==3.1.2
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -136,7 +123,7 @@ packaging==21.3
     # via
     #   -r requirements/ci.txt
     #   tox
-path==16.2.0
+path==16.4.0
     # via edx-i18n-tools
 pbr==5.8.1
     # via
@@ -172,13 +159,9 @@ py==1.11.0
     #   tox
 pycodestyle==2.8.0
     # via -r requirements/quality.txt
-pycparser==2.21
-    # via
-    #   -r requirements/quality.txt
-    #   cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.txt
-pygments==2.11.2
+pygments==2.12.0
     # via
     #   -r requirements/quality.txt
     #   diff-cover
@@ -208,7 +191,7 @@ pyparsing==3.0.8
     # via
     #   -r requirements/ci.txt
     #   packaging
-python-slugify==6.1.1
+python-slugify==6.1.2
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -240,16 +223,12 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==12.2.0
+rich==12.3.0
     # via
     #   -r requirements/quality.txt
     #   twine
 rstcheck==5.0.0
     # via -r requirements/quality.txt
-secretstorage==3.3.1
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 six==1.16.0
     # via
     #   -r requirements/ci.txt
@@ -323,7 +302,7 @@ wheel==0.37.1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-wrapt==1.14.0
+wrapt==1.14.1
     # via
     #   -r requirements/quality.txt
     #   astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 amqp==5.1.1
     # via kombu
-asgiref==3.5.0
+asgiref==3.5.1
     # via django
 babel==2.10.1
     # via sphinx
@@ -26,7 +26,7 @@ cffi==1.15.0
     # via cryptography
 charset-normalizer==2.0.12
     # via requests
-click==8.1.2
+click==8.1.3
     # via
     #   celery
     #   click-didyoumean
@@ -47,7 +47,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==36.0.2
+cryptography==37.0.1
     # via pyjwt
 django==3.2.13
     # via
@@ -134,7 +134,7 @@ inflection==0.5.1
     # via drf-yasg
 itypes==1.2.0
     # via coreapi
-jinja2==3.1.1
+jinja2==3.1.2
     # via
     #   code-annotations
     #   coreschema
@@ -163,7 +163,7 @@ pycparser==2.21
     # via cffi
 pycryptodomex==3.14.1
     # via pyjwkest
-pygments==2.11.2
+pygments==2.12.0
     # via
     #   doc8
     #   readme-renderer
@@ -180,7 +180,7 @@ pyparsing==3.0.8
     # via packaging
 python-dateutil==2.8.2
     # via edx-drf-extensions
-python-slugify==6.1.1
+python-slugify==6.1.2
     # via code-annotations
 pytz==2022.1
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-click==8.1.2
+click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.1
     # via django
-astroid==2.11.3
+astroid==2.11.4
     # via
     #   pylint
     #   pylint-celery
@@ -14,11 +14,9 @@ bleach==5.0.0
     # via readme-renderer
 certifi==2021.10.8
     # via requests
-cffi==1.15.0
-    # via cryptography
 charset-normalizer==2.0.12
     # via requests
-click==8.1.2
+click==8.1.3
     # via
     #   click-log
     #   code-annotations
@@ -29,8 +27,6 @@ code-annotations==1.3.0
     # via edx-lint
 commonmark==0.9.1
     # via rich
-cryptography==36.0.2
-    # via secretstorage
 dill==0.3.4
     # via pylint
 django==3.2.13
@@ -53,11 +49,7 @@ isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
-jinja2==3.1.1
+jinja2==3.1.2
     # via code-annotations
 keyring==23.5.0
     # via twine
@@ -75,11 +67,9 @@ platformdirs==2.5.2
     # via pylint
 pycodestyle==2.8.0
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.in
-pygments==2.11.2
+pygments==2.12.0
     # via
     #   readme-renderer
     #   rich
@@ -97,7 +87,7 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-python-slugify==6.1.1
+python-slugify==6.1.2
     # via code-annotations
 pytz==2022.1
     # via django
@@ -113,12 +103,10 @@ requests-toolbelt==0.9.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==12.2.0
+rich==12.3.0
     # via twine
 rstcheck==5.0.0
     # via -r requirements/quality.in
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   bleach
@@ -149,7 +137,7 @@ urllib3==1.26.9
     #   twine
 webencodings==0.5.1
     # via bleach
-wrapt==1.14.0
+wrapt==1.14.1
     # via astroid
 zipp==3.8.0
     # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -192,10 +192,8 @@ pbr==5.8.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-pluggy==0.13.1
-    # via
-    #   -c requirements/constraints.txt
-    #   pytest
+pluggy==1.0.0
+    # via pytest
 prompt-toolkit==3.0.29
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,7 +7,7 @@
     # via
     #   -r requirements/base.txt
     #   kombu
-asgiref==3.5.0
+asgiref==3.5.1
     # via
     #   -r requirements/base.txt
     #   django
@@ -32,7 +32,7 @@ charset-normalizer==2.0.12
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.2
+click==8.1.3
     # via
     #   -r requirements/base.txt
     #   celery
@@ -68,7 +68,7 @@ coreschema==0.0.4
     #   drf-yasg
 coverage[toml]==6.3.2
     # via pytest-cov
-cryptography==36.0.2
+cryptography==37.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -161,7 +161,7 @@ itypes==1.2.0
     # via
     #   -r requirements/base.txt
     #   coreapi
-jinja2==3.1.1
+jinja2==3.1.2
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -231,7 +231,7 @@ pyparsing==3.0.8
     # via
     #   -r requirements/base.txt
     #   packaging
-pytest==7.1.1
+pytest==7.1.2
     # via
     #   pytest-cov
     #   pytest-django
@@ -243,7 +243,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-python-slugify==6.1.1
+python-slugify==6.1.2
     # via
     #   -r requirements/base.txt
     #   code-annotations


### PR DESCRIPTION
pluggy version conflicts generated from other requirements seem to have resolved to 1.0.0 so we can remove that constraint