### PR TITLE
fix: allow verified name to be created if user is trying to verify with the same name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[2.3.4] - 2022-05-17
+~~~~~~~~~~~~~~~~~~~~
+* Fix bug that prevents new verified names from being created if the user is trying to verify the same name
+
 [2.3.3] - 2022-04-21
 ~~~~~~~~~~~~~~~~~~~~
 * Leverage edx-api-doc-tools to provide better swagger documentation for the RESTFul API endpoints

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,6 +2,6 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '2.3.3'
+__version__ = '2.3.4'
 
 default_app_config = 'edx_name_affirmation.apps.EdxNameAffirmationConfig'  # pylint: disable=invalid-name

--- a/edx_name_affirmation/tasks.py
+++ b/edx_name_affirmation/tasks.py
@@ -9,6 +9,7 @@ from celery import shared_task
 from edx_django_utils.monitoring import set_code_owner_attribute
 
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 
 from edx_name_affirmation.models import VerifiedName
 from edx_name_affirmation.statuses import VerifiedNameStatus
@@ -37,7 +38,15 @@ def idv_update_verified_name_task(self, attempt_id, user_id, name_affirmation_st
                 'status': name_affirmation_status
              }
              )
-    verified_names = VerifiedName.objects.filter(user__id=user_id, verified_name=photo_id_name).order_by('-created')
+    # get all verified names that are either not associated with an IDV attempt, or
+    # only associated with the IDV attempt for which we received an update. We do not
+    # want to grab all verified names for the same user and name combination, because
+    # some of those records may already be associated with a different IDV attempt.
+    verified_names = VerifiedName.objects.filter(
+        (Q(verification_attempt_id=attempt_id) | Q(verification_attempt_id__isnull=True))
+        & Q(user__id=user_id)
+        & Q(verified_name=photo_id_name)
+    ).order_by('-created')
     if verified_names:
         # if there are VerifiedName objects, we want to update existing entries
         # for each attempt with no attempt id (either proctoring or idv), update attempt id


### PR DESCRIPTION
**Description:**

Currently if a user tries to submit an IDV attempt with the same name as a previous IDV attempt that was reviewed, no verified name record will be created for them. 

Splunk logs will show that in this case, it looks like a verified name _is_ actually created for the learner, even though no record is actually created.

**JIRA:**

[MST-1514](https://2u-internal.atlassian.net/browse/MST-1514)

**Pre-Merge Checklist:**

- [x] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [x] Described your changes in `CHANGELOG.rst`.
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
