### PR TITLE
build: no need for Open edX branching, because this repo is a dependency.

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -15,9 +15,5 @@ oeps:
     oep-18: true  # Dependency management
     oep-30:  # PII annotation
         state: true
-openedx-release:
-    # The openedx-release key is described in OEP-10:
-    #   https://open-edx-proposals.readthedocs.io/en/latest/oep-0010-proc-openedx-releases.html
-    # The FAQ might also be helpful: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1331268879/Open+edX+Release+FAQ
-    maybe: true   # Delete this "maybe" line when you have decided about Open edX inclusion.
-    ref: main
+# This repo doesn't need release branches, because it's a dependency
+# of edx-platform.


### PR DESCRIPTION
Update the release metadata ahead of the Olive release.