### PR TITLE
Add IDV Status to VerifiedName

### DIFF
--- a/edx_name_affirmation/models.py
+++ b/edx_name_affirmation/models.py
@@ -11,6 +11,11 @@ from django.db import models
 
 from edx_name_affirmation.statuses import VerifiedNameStatus
 
+try:
+    from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
+except ImportError:
+    SoftwareSecurePhotoVerification = None
+
 User = get_user_model()
 
 
@@ -47,13 +52,12 @@ class VerifiedName(TimeStampedModel):
 
     @property
     def verification_attempt_status(self):
-        if not self.verification_attempt_id:
+        "Returns the status associated with its SoftwareSecurePhotoVerification with verification_attempt_id if any."
+
+        if not self.verification_attempt_id or not SoftwareSecurePhotoVerification:
             return None
 
-        try:
-            from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
-        except ImportError:
-            return None
+        # breakpoint()
 
         verification = SoftwareSecurePhotoVerification.objects.get(id=self.verification_attempt_id)
 

--- a/edx_name_affirmation/models.py
+++ b/edx_name_affirmation/models.py
@@ -7,6 +7,7 @@ from model_utils.models import TimeStampedModel
 from simple_history.models import HistoricalRecords
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 
 from edx_name_affirmation.statuses import VerifiedNameStatus
@@ -61,8 +62,9 @@ class VerifiedName(TimeStampedModel):
             verification = SoftwareSecurePhotoVerification.objects.get(id=self.verification_attempt_id)
             return verification.status if verification else None
 
-        except SoftwareSecurePhotoVerification.DoesNotExist:
+        except ObjectDoesNotExist:
             return None
+
 
 class VerifiedNameConfig(ConfigurationModel):
     """

--- a/edx_name_affirmation/models.py
+++ b/edx_name_affirmation/models.py
@@ -57,12 +57,12 @@ class VerifiedName(TimeStampedModel):
         if not self.verification_attempt_id or not SoftwareSecurePhotoVerification:
             return None
 
-        # breakpoint()
+        try:
+            verification = SoftwareSecurePhotoVerification.objects.get(id=self.verification_attempt_id)
+            return verification.status if verification else None
 
-        verification = SoftwareSecurePhotoVerification.objects.get(id=self.verification_attempt_id)
-
-        return verification.status if verification else None
-
+        except SoftwareSecurePhotoVerification.DoesNotExist:
+            return None
 
 class VerifiedNameConfig(ConfigurationModel):
     """

--- a/edx_name_affirmation/models.py
+++ b/edx_name_affirmation/models.py
@@ -60,7 +60,7 @@ class VerifiedName(TimeStampedModel):
 
         try:
             verification = SoftwareSecurePhotoVerification.objects.get(id=self.verification_attempt_id)
-            return verification.status if verification else None
+            return verification.status
 
         except ObjectDoesNotExist:
             return None

--- a/edx_name_affirmation/models.py
+++ b/edx_name_affirmation/models.py
@@ -45,6 +45,20 @@ class VerifiedName(TimeStampedModel):
         db_table = 'nameaffirmation_verifiedname'
         verbose_name = 'verified name'
 
+    @property
+    def verification_attempt_status(self):
+        if not self.verification_attempt_id:
+            return None
+
+        try:
+            from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
+        except ImportError:
+            return None
+
+        verification = SoftwareSecurePhotoVerification.objects.get(id=self.verification_attempt_id)
+
+        return verification.status if verification else None
+
 
 class VerifiedNameConfig(ConfigurationModel):
     """

--- a/edx_name_affirmation/serializers.py
+++ b/edx_name_affirmation/serializers.py
@@ -19,24 +19,9 @@ class VerifiedNameSerializer(serializers.ModelSerializer):
     verified_name = serializers.CharField(required=True)
     profile_name = serializers.CharField(required=True)
     verification_attempt_id = serializers.IntegerField(required=False, allow_null=True)
-    verification_attempt_status = serializers.SerializerMethodField('get_verification_attempt_status')
+    verification_attempt_status = serializers.CharField(required=False, allow_null=True)
     proctored_exam_attempt_id = serializers.IntegerField(required=False, allow_null=True)
     status = serializers.CharField(required=False, allow_null=True)
-
-    def get_verification_attempt_status(self, obj):
-        try:
-            from lms.djangoapps.verify_student.services import IDVerificationService # pylint: disable=import-error,import-outside-toplevel
-        except ImportError:
-            return None
-
-        idv_attempt_id = obj.verification_attempt_id
-
-        if not idv_attempt_id:
-            return None
-
-        verification = IDVerificationService.get_verification_details_by_id(idv_attempt_id)
-
-        return verification.status if verification else None
 
     class Meta:
         """

--- a/edx_name_affirmation/tests/test_models.py
+++ b/edx_name_affirmation/tests/test_models.py
@@ -1,6 +1,7 @@
 """
 Tests for Name Affirmation models
 """
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -8,12 +9,13 @@ from django.test import TestCase
 from edx_name_affirmation.models import VerifiedName
 from edx_name_affirmation.statuses import VerifiedNameStatus
 
-try:
-    from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
-except ImportError:
-    pass
-
 User = get_user_model()
+
+
+def _obj(dictionary):
+    "Helper method to turn a dict into an object. Used to mock below."
+
+    return type('obj', (object,), dictionary)
 
 
 class VerifiedNameModelTests(TestCase):
@@ -30,15 +32,24 @@ class VerifiedNameModelTests(TestCase):
         )
         return super().setUp()
 
-    def test_histories(self):
+    @patch('edx_name_affirmation.models.SoftwareSecurePhotoVerification')
+    def test_histories(self, sspv_mock):
         """
         Test the model history is recording records as expected
         """
+        idv_attempt_id = 34455
+        idv_attempt_status = 'submitted'
+
+        sspv_mock.objects.get = lambda id: \
+            _obj({'status': idv_attempt_status}) if id == idv_attempt_id \
+            else _obj({'status': None})
+
         verified_name_history = self.verified_name.history.all().order_by('history_date')
         assert len(verified_name_history) == 1
-        idv_attempt_id = 34455
         self.verified_name.status = VerifiedNameStatus.APPROVED
         self.verified_name.verification_attempt_id = idv_attempt_id
+
+        assert self.verified_name.verification_attempt_status is idv_attempt_status
         self.verified_name.save()
         verified_name_history = self.verified_name.history.all().order_by('history_date')
         assert len(verified_name_history) == 2

--- a/edx_name_affirmation/tests/test_models.py
+++ b/edx_name_affirmation/tests/test_models.py
@@ -32,24 +32,16 @@ class VerifiedNameModelTests(TestCase):
         )
         return super().setUp()
 
-    @patch('edx_name_affirmation.models.SoftwareSecurePhotoVerification')
-    def test_histories(self, sspv_mock):
+    def test_histories(self):
         """
         Test the model history is recording records as expected
         """
         idv_attempt_id = 34455
-        idv_attempt_status = 'submitted'
-
-        sspv_mock.objects.get = lambda id: \
-            _obj({'status': idv_attempt_status}) if id == idv_attempt_id \
-            else _obj({'status': None})
 
         verified_name_history = self.verified_name.history.all().order_by('history_date')
         assert len(verified_name_history) == 1
         self.verified_name.status = VerifiedNameStatus.APPROVED
         self.verified_name.verification_attempt_id = idv_attempt_id
-
-        assert self.verified_name.verification_attempt_status is idv_attempt_status
         self.verified_name.save()
         verified_name_history = self.verified_name.history.all().order_by('history_date')
         assert len(verified_name_history) == 2
@@ -61,3 +53,21 @@ class VerifiedNameModelTests(TestCase):
         second_history_record = verified_name_history[1]
         assert second_history_record.status == VerifiedNameStatus.APPROVED
         assert second_history_record.verification_attempt_id == idv_attempt_id
+
+    @patch('edx_name_affirmation.models.SoftwareSecurePhotoVerification')
+    def test_verification_status(self, sspv_mock):
+        """
+        Test the model history is recording records as expected
+        """
+        idv_attempt_id = 34455
+        idv_attempt_status = 'submitted'
+
+        sspv_mock.objects.get = lambda id: \
+            _obj({'status': idv_attempt_status}) if id == idv_attempt_id \
+            else _obj({'status': None})
+
+        self.verified_name.verification_attempt_id = 12345
+        assert self.verified_name.verification_attempt_status is None
+
+        self.verified_name.verification_attempt_id = idv_attempt_id
+        assert self.verified_name.verification_attempt_status is idv_attempt_status

--- a/edx_name_affirmation/tests/test_models.py
+++ b/edx_name_affirmation/tests/test_models.py
@@ -8,6 +8,11 @@ from django.test import TestCase
 from edx_name_affirmation.models import VerifiedName
 from edx_name_affirmation.statuses import VerifiedNameStatus
 
+try:
+    from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
+except ImportError:
+    pass
+
 User = get_user_model()
 
 

--- a/edx_name_affirmation/tests/test_models.py
+++ b/edx_name_affirmation/tests/test_models.py
@@ -12,6 +12,7 @@ from edx_name_affirmation.statuses import VerifiedNameStatus
 
 User = get_user_model()
 
+
 class VerifiedNameModelTests(TestCase):
     """
     Test suite for the VerifiedName models

--- a/edx_name_affirmation/tests/test_views.py
+++ b/edx_name_affirmation/tests/test_views.py
@@ -8,6 +8,7 @@ import ddt
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.urls import reverse
+from functools import partial
 
 from edx_name_affirmation.api import (
     create_verified_name,
@@ -37,6 +38,7 @@ class NameAffirmationViewsTestCase(LoggedInTestCase):
         # Create fresh configs with default values
         VerifiedNameConfig.objects.create(user=self.user)
         VerifiedNameConfig.objects.create(user=self.other_user)
+        self.json_post = partial(self.client.post, content_type="application/json")
 
     def tearDown(self):
         super().tearDown()
@@ -116,7 +118,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'verification_attempt_id': self.ATTEMPT_ID,
             'verification_attempt_status': None,
         }
-        response = self.client.post(
+        response = self.json_post(
             reverse('edx_name_affirmation:verified_name'),
             verified_name_data
         )
@@ -140,9 +142,10 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'verification_attempt_status': None,
             'status': VerifiedNameStatus.APPROVED.value,
         }
-        response = self.client.post(
+        response = self.json_post(
             reverse('edx_name_affirmation:verified_name'),
-            verified_name_data
+            verified_name_data,
+            content_type='json'
         )
         self.assertEqual(response.status_code, 200)
 
@@ -161,7 +164,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'verification_attempt_status': None,
             'status': VerifiedNameStatus.APPROVED.value,
         }
-        response = self.client.post(
+        response = self.json_post(
             reverse('edx_name_affirmation:verified_name'),
             verified_name_data
         )
@@ -177,7 +180,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'verification_attempt_status': None,
             'status': VerifiedNameStatus.SUBMITTED.value,
         }
-        response = self.client.post(
+        response = self.json_post(
             reverse('edx_name_affirmation:verified_name'),
             verified_name_data
         )
@@ -192,7 +195,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'verification_attempt_status': None,
             'status': VerifiedNameStatus.APPROVED.value,
         }
-        response = self.client.post(
+        response = self.json_post(
             reverse('edx_name_affirmation:verified_name'),
             verified_name_data
         )
@@ -206,7 +209,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'verification_attempt_id': self.ATTEMPT_ID,
             'proctored_exam_attempt_id': self.ATTEMPT_ID
         }
-        response = self.client.post(
+        response = self.json_post(
             reverse('edx_name_affirmation:verified_name'),
             verified_name_data
         )
@@ -480,7 +483,7 @@ class VerifiedNameConfigViewTests(NameAffirmationViewsTestCase):
             'username': self.user.username,
             'use_verified_name_for_certs': True
         }
-        response = self.client.post(
+        response = self.json_post(
             reverse('edx_name_affirmation:verified_name_config'),
             config_data
         )
@@ -496,11 +499,11 @@ class VerifiedNameConfigViewTests(NameAffirmationViewsTestCase):
         }
         config_data_missing_field = {'username': self.user.username}
 
-        first_response = self.client.post(
+        first_response = self.json_post(
             reverse('edx_name_affirmation:verified_name_config'),
             initial_config_data
         )
-        second_response = self.client.post(
+        second_response = self.json_post(
             reverse('edx_name_affirmation:verified_name_config'),
             config_data_missing_field
         )
@@ -520,7 +523,7 @@ class VerifiedNameConfigViewTests(NameAffirmationViewsTestCase):
             'username': self.other_user.username,
             'use_verified_name_for_certs': True
         }
-        response = self.client.post(
+        response = self.json_post(
             reverse('edx_name_affirmation:verified_name_config'),
             config_data
         )
@@ -534,7 +537,7 @@ class VerifiedNameConfigViewTests(NameAffirmationViewsTestCase):
             'username': self.other_user.username,
             'use_verified_name_for_certs': True
         }
-        response = self.client.post(
+        response = self.json_post(
             reverse('edx_name_affirmation:verified_name_config'),
             config_data
         )
@@ -545,7 +548,7 @@ class VerifiedNameConfigViewTests(NameAffirmationViewsTestCase):
             'username': self.user.username,
             'use_verified_name_for_certs': 'not a boolean'
         }
-        response = self.client.post(
+        response = self.json_post(
             reverse('edx_name_affirmation:verified_name_config'),
             config_data
         )

--- a/edx_name_affirmation/tests/test_views.py
+++ b/edx_name_affirmation/tests/test_views.py
@@ -139,7 +139,6 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'proctored_exam_attempt_id': self.ATTEMPT_ID,
             'verification_attempt_status': None,
             'status': VerifiedNameStatus.APPROVED.value,
-
         }
         response = self.client.post(
             reverse('edx_name_affirmation:verified_name'),

--- a/edx_name_affirmation/tests/test_views.py
+++ b/edx_name_affirmation/tests/test_views.py
@@ -114,6 +114,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'profile_name': self.PROFILE_NAME,
             'verified_name': self.VERIFIED_NAME,
             'verification_attempt_id': self.ATTEMPT_ID,
+            'verification_attempt_status': None,
         }
         response = self.client.post(
             reverse('edx_name_affirmation:verified_name'),
@@ -136,7 +137,9 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'profile_name': self.PROFILE_NAME,
             'verified_name': self.VERIFIED_NAME,
             'proctored_exam_attempt_id': self.ATTEMPT_ID,
+            'verification_attempt_status': None,
             'status': VerifiedNameStatus.APPROVED.value,
+
         }
         response = self.client.post(
             reverse('edx_name_affirmation:verified_name'),
@@ -156,6 +159,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'profile_name': self.PROFILE_NAME,
             'verified_name': self.VERIFIED_NAME,
             'verification_attempt_id': self.ATTEMPT_ID,
+            'verification_attempt_status': None,
             'status': VerifiedNameStatus.APPROVED.value,
         }
         response = self.client.post(
@@ -171,6 +175,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'profile_name': self.PROFILE_NAME,
             'verified_name': verified_name,
             'verification_attempt_id': self.ATTEMPT_ID,
+            'verification_attempt_status': None,
             'status': VerifiedNameStatus.SUBMITTED.value,
         }
         response = self.client.post(
@@ -185,6 +190,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'profile_name': self.PROFILE_NAME,
             'verified_name': self.VERIFIED_NAME,
             'verification_attempt_id': 'xxyz',
+            'verification_attempt_status': None,
             'status': VerifiedNameStatus.APPROVED.value,
         }
         response = self.client.post(
@@ -357,6 +363,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'verified_name': verified_name_obj.verified_name,
             'profile_name': verified_name_obj.profile_name,
             'verification_attempt_id': verified_name_obj.verification_attempt_id,
+            'verification_attempt_status': None,
             'proctored_exam_attempt_id': verified_name_obj.proctored_exam_attempt_id,
             'status': verified_name_obj.status,
             'use_verified_name_for_certs': use_verified_name_for_certs,

--- a/edx_name_affirmation/tests/test_views.py
+++ b/edx_name_affirmation/tests/test_views.py
@@ -8,7 +8,6 @@ import ddt
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.urls import reverse
-from functools import partial
 
 from edx_name_affirmation.api import (
     create_verified_name,
@@ -38,7 +37,6 @@ class NameAffirmationViewsTestCase(LoggedInTestCase):
         # Create fresh configs with default values
         VerifiedNameConfig.objects.create(user=self.user)
         VerifiedNameConfig.objects.create(user=self.other_user)
-        self.json_post = partial(self.client.post, content_type="application/json")
 
     def tearDown(self):
         super().tearDown()
@@ -116,9 +114,8 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'profile_name': self.PROFILE_NAME,
             'verified_name': self.VERIFIED_NAME,
             'verification_attempt_id': self.ATTEMPT_ID,
-            'verification_attempt_status': None,
         }
-        response = self.json_post(
+        response = self.client.post(
             reverse('edx_name_affirmation:verified_name'),
             verified_name_data
         )
@@ -139,13 +136,11 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'profile_name': self.PROFILE_NAME,
             'verified_name': self.VERIFIED_NAME,
             'proctored_exam_attempt_id': self.ATTEMPT_ID,
-            'verification_attempt_status': None,
             'status': VerifiedNameStatus.APPROVED.value,
         }
-        response = self.json_post(
+        response = self.client.post(
             reverse('edx_name_affirmation:verified_name'),
-            verified_name_data,
-            content_type='json'
+            verified_name_data
         )
         self.assertEqual(response.status_code, 200)
 
@@ -161,10 +156,9 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'profile_name': self.PROFILE_NAME,
             'verified_name': self.VERIFIED_NAME,
             'verification_attempt_id': self.ATTEMPT_ID,
-            'verification_attempt_status': None,
             'status': VerifiedNameStatus.APPROVED.value,
         }
-        response = self.json_post(
+        response = self.client.post(
             reverse('edx_name_affirmation:verified_name'),
             verified_name_data
         )
@@ -177,10 +171,9 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'profile_name': self.PROFILE_NAME,
             'verified_name': verified_name,
             'verification_attempt_id': self.ATTEMPT_ID,
-            'verification_attempt_status': None,
             'status': VerifiedNameStatus.SUBMITTED.value,
         }
-        response = self.json_post(
+        response = self.client.post(
             reverse('edx_name_affirmation:verified_name'),
             verified_name_data
         )
@@ -192,10 +185,9 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'profile_name': self.PROFILE_NAME,
             'verified_name': self.VERIFIED_NAME,
             'verification_attempt_id': 'xxyz',
-            'verification_attempt_status': None,
             'status': VerifiedNameStatus.APPROVED.value,
         }
-        response = self.json_post(
+        response = self.client.post(
             reverse('edx_name_affirmation:verified_name'),
             verified_name_data
         )
@@ -209,7 +201,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'verification_attempt_id': self.ATTEMPT_ID,
             'proctored_exam_attempt_id': self.ATTEMPT_ID
         }
-        response = self.json_post(
+        response = self.client.post(
             reverse('edx_name_affirmation:verified_name'),
             verified_name_data
         )
@@ -465,6 +457,7 @@ class VerifiedNameHistoryViewTests(NameAffirmationViewsTestCase):
                 'verified_name': verified_name_obj.verified_name,
                 'profile_name': verified_name_obj.profile_name,
                 'verification_attempt_id': verified_name_obj.verification_attempt_id,
+                'verification_attempt_status': None,
                 'proctored_exam_attempt_id': verified_name_obj.proctored_exam_attempt_id,
                 'status': verified_name_obj.status
             }
@@ -483,7 +476,7 @@ class VerifiedNameConfigViewTests(NameAffirmationViewsTestCase):
             'username': self.user.username,
             'use_verified_name_for_certs': True
         }
-        response = self.json_post(
+        response = self.client.post(
             reverse('edx_name_affirmation:verified_name_config'),
             config_data
         )
@@ -499,11 +492,11 @@ class VerifiedNameConfigViewTests(NameAffirmationViewsTestCase):
         }
         config_data_missing_field = {'username': self.user.username}
 
-        first_response = self.json_post(
+        first_response = self.client.post(
             reverse('edx_name_affirmation:verified_name_config'),
             initial_config_data
         )
-        second_response = self.json_post(
+        second_response = self.client.post(
             reverse('edx_name_affirmation:verified_name_config'),
             config_data_missing_field
         )
@@ -523,7 +516,7 @@ class VerifiedNameConfigViewTests(NameAffirmationViewsTestCase):
             'username': self.other_user.username,
             'use_verified_name_for_certs': True
         }
-        response = self.json_post(
+        response = self.client.post(
             reverse('edx_name_affirmation:verified_name_config'),
             config_data
         )
@@ -537,7 +530,7 @@ class VerifiedNameConfigViewTests(NameAffirmationViewsTestCase):
             'username': self.other_user.username,
             'use_verified_name_for_certs': True
         }
-        response = self.json_post(
+        response = self.client.post(
             reverse('edx_name_affirmation:verified_name_config'),
             config_data
         )
@@ -548,7 +541,7 @@ class VerifiedNameConfigViewTests(NameAffirmationViewsTestCase):
             'username': self.user.username,
             'use_verified_name_for_certs': 'not a boolean'
         }
-        response = self.json_post(
+        response = self.client.post(
             reverse('edx_name_affirmation:verified_name_config'),
             config_data
         )


### PR DESCRIPTION
**Description:**

The purpose of this update is to decouple the [VerifiedName](https://github.com/openedx/frontend-app-support-tools/blob/e96d171f8241026652abdfcd319a70f2d33d31aa/src/users/VerifiedName.jsx#L15) component in the [Support Tools MFE](https://github.com/openedx/frontend-app-support-tools) from the [verify_student](https://github.com/openedx/edx-platform/tree/master/lms/djangoapps/verify_student) application. The [VerifiedName](https://github.com/openedx/frontend-app-support-tools/blob/e96d171f8241026652abdfcd319a70f2d33d31aa/src/users/VerifiedName.jsx#L15) component is used to display a table of verified name information in the [Support Tools](https://github.com/openedx/frontend-app-support-tools). A screenshot is attached.

The solution might not be the most optimal, since it would make a call for each individual `VerifiedName`, but it's made like this due to the `verification_attempt_id` not having a proper foreign key currently in the database. This shouldn't be a problem since the verified names per user are at most just a few rows. This would be revisited in the near future.

**Screenshot**

![image](https://github.com/user-attachments/assets/87ec2bb1-8f34-4d2c-af66-c23dc933714c)

**JIRA:**

[COSMO-442](https://2u-internal.atlassian.net/browse/COSMO-442)🔒

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [ ] Described your changes in `CHANGELOG.rst`.
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
