### PR TITLE
Fix permissions issues for python-coverage-comment action step

### DIFF
--- a/.github/coverage.yml
+++ b/.github/coverage.yml
@@ -1,0 +1,36 @@
+# .github/workflows/coverage.yml
+name: Post coverage comment
+
+on:
+  workflow_run:
+    workflows: ["Python CI"]
+    types:
+      - completed
+
+jobs:
+  test:
+    name: Run tests & display coverage
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      # Gives the action the necessary permissions for publishing new
+      # comments in pull requests.
+      pull-requests: write
+      # Gives the action the necessary permissions for editing existing
+      # comments (to avoid publishing multiple comments in the same PR)
+      contents: write
+      # Gives the action the necessary permissions for looking up the
+      # workflow that launched this workflow, and download the related
+      # artifact that contains the comment to be published
+      actions: read
+    steps:
+      # DO NOT run actions/checkout here, for security reasons
+      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: Post comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
+          # Update those if you changed the default values:
+          # COMMENT_ARTIFACT_NAME: python-coverage-comment-action
+          # COMMENT_FILENAME: python-coverage-comment-action.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,24 @@ jobs:
           ANNOTATE_MISSING_LINES: true
           ANNOTATION_TYPE: error
           uses: codecov/codecov-action@v2
+
+      - name: Report coverage
+        id: coverage_comment
+        if: matrix.toxenv == 'django42'
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          MINIMUM_GREEN: 95
+          MINIMUM_ORANGE: 84
+          ANNOTATE_MISSING_LINES: true
+          ANNOTATION_TYPE: error
+          uses: codecov/codecov-action@v2
+
+      - name: Store pll request coverage comment to post in another action
+        uses: actions/upload-artifact@v4
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        with:
+          # If you use a different name, update COMMENT_ARTIFACT_NAME accordingly
+          name: python-coverage-comment-action
+          # If you use a different name, update COMMENT_FILENAME accordingly
+          path: python-coverage-comment-action.txt


### PR DESCRIPTION
**Description:**

When a user without the proper permissions on the repository authors a commit, the `python-coverage-comment` step in the CI action fails because the user does not have permissions to post comments to the pull request.

In order to fix this, split the coverage step into two.

1. In ci.yml, checkout the repository and generate and save the coverage comment that should be posted.
2. In coverage.yml, publish the saved coverage comment to the pull request. For security reasons, we do not want to give permissions to the ci.yml action, because it checks out untrusted code. Coverage.yml is a trusted workflow that can post the saved coverage comment from the untrusted workflow.

**JIRA:**

None.

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [ ] Described your changes in `CHANGELOG.rst`.
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
