### PR TITLE
feat: integrate platform verification attempt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 * Add platform verification id field to the VerifiedName model
+* Integrate platform verification id into app
 
 [2.4.0] - 2024-04-23
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_name_affirmation/admin.py
+++ b/edx_name_affirmation/admin.py
@@ -14,10 +14,13 @@ class VerifiedNameAdmin(admin.ModelAdmin):
     """
     list_display = (
       'id', 'user', 'verified_name', 'verification_attempt_id', 'proctored_exam_attempt_id',
-      'status', 'created', 'modified',
+      'platform_verification_attempt_id', 'status', 'created', 'modified',
     )
     readonly_fields = ('id',)
-    search_fields = ('user__username', 'verification_attempt_id', 'proctored_exam_attempt_id',)
+    search_fields = (
+        'user__username', 'verification_attempt_id', 'proctored_exam_attempt_id',
+        'platform_verification_attempt_id'
+    )
     raw_id_fields = ('user', )
 
 

--- a/edx_name_affirmation/models.py
+++ b/edx_name_affirmation/models.py
@@ -14,8 +14,10 @@ from edx_name_affirmation.statuses import VerifiedNameStatus
 
 try:
     from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
+    from lms.djangoapps.verify_studnet.models import VerificationAttempt as PlatformVerificationAttempt
 except ImportError:
     SoftwareSecurePhotoVerification = None
+    PlatformVerificationAttempt = None
 
 User = get_user_model()
 
@@ -72,6 +74,21 @@ class VerifiedName(TimeStampedModel):
 
         try:
             verification = SoftwareSecurePhotoVerification.objects.get(id=self.verification_attempt_id)
+            return verification.status
+
+        except ObjectDoesNotExist:
+            return None
+
+    @property
+    def platform_verification_attempt_status(self):
+        """
+        Returns the status associated with its platform VerificationAttempt
+        """
+        if not self.platform_verification_attempt_id or not PlatformVerificationAttempt:
+            return None
+
+        try:
+            verification = PlatformVerificationAttempt.objects.get(id=self.platform_verification_attempt_id)
             return verification.status
 
         except ObjectDoesNotExist:

--- a/edx_name_affirmation/serializers.py
+++ b/edx_name_affirmation/serializers.py
@@ -22,6 +22,8 @@ class VerifiedNameSerializer(serializers.ModelSerializer):
     verification_attempt_status = serializers.CharField(required=False, allow_null=True)
     proctored_exam_attempt_id = serializers.IntegerField(required=False, allow_null=True)
     status = serializers.CharField(required=False, allow_null=True)
+    platform_verification_attempt_id = serializers.IntegerField(required=False, allow_null=True)
+    platform_verification_attempt_status = serializers.CharField(required=False, allow_null=True)
 
     class Meta:
         """
@@ -31,7 +33,8 @@ class VerifiedNameSerializer(serializers.ModelSerializer):
 
         fields = (
             "id", "created", "username", "verified_name", "profile_name", "verification_attempt_id",
-            "verification_attempt_status", "proctored_exam_attempt_id", "status"
+            "verification_attempt_status", "proctored_exam_attempt_id", "platform_verification_attempt_id",
+            "platform_verification_attempt_status", "status"
         )
 
     def validate_verified_name(self, verified_name):

--- a/edx_name_affirmation/tests/test_api.py
+++ b/edx_name_affirmation/tests/test_api.py
@@ -14,7 +14,6 @@ from edx_name_affirmation.api import (
     get_verified_name,
     get_verified_name_history,
     should_use_verified_name_for_certs,
-    update_verification_attempt_id,
     update_verified_name_status
 )
 from edx_name_affirmation.exceptions import (
@@ -23,7 +22,7 @@ from edx_name_affirmation.exceptions import (
     VerifiedNameEmptyString,
     VerifiedNameMultipleAttemptIds
 )
-from edx_name_affirmation.models import VerifiedName, VerifiedNameConfig
+from edx_name_affirmation.models import VerifiedNameConfig
 from edx_name_affirmation.statuses import VerifiedNameStatus
 
 User = get_user_model()
@@ -38,6 +37,7 @@ class TestVerifiedNameAPI(TestCase):
     PROFILE_NAME = 'Jon Doe'
     VERIFICATION_ATTEMPT_ID = 123
     PROCTORED_EXAM_ATTEMPT_ID = 456
+    PLATFORM_VERIFICATION_ATTEMPT_ID = 789
 
     def setUp(self):
         super().setUp()
@@ -62,25 +62,36 @@ class TestVerifiedNameAPI(TestCase):
         self.assertEqual(verified_name_obj.status, VerifiedNameStatus.PENDING.value)
 
     @ddt.data(
-        (123, None, VerifiedNameStatus.APPROVED),
-        (None, 456, VerifiedNameStatus.SUBMITTED),
+        (123, None, None, VerifiedNameStatus.APPROVED),
+        (None, 456, None, VerifiedNameStatus.SUBMITTED),
+        (None, None, 789, VerifiedNameStatus.SUBMITTED),
     )
     @ddt.unpack
     def test_create_verified_name_with_optional_arguments(
-        self, verification_attempt_id, proctored_exam_attempt_id, status,
+        self, verification_attempt_id, proctored_exam_attempt_id, platform_verification_attempt_id, status,
     ):
         """
         Test to create a verified name with optional arguments supplied.
         """
         verified_name_obj = self._create_verified_name(
-            verification_attempt_id, proctored_exam_attempt_id, status,
+            verification_attempt_id, proctored_exam_attempt_id, platform_verification_attempt_id, status,
         )
 
         self.assertEqual(verified_name_obj.verification_attempt_id, verification_attempt_id)
         self.assertEqual(verified_name_obj.proctored_exam_attempt_id, proctored_exam_attempt_id)
+        self.assertEqual(verified_name_obj.platform_verification_attempt_id, platform_verification_attempt_id)
         self.assertEqual(verified_name_obj.status, status.value)
 
-    def test_create_verified_name_two_ids(self):
+    @ddt.data(
+        (123, 456, None),
+        (123, None, 789),
+        (None, 456, 789),
+        (123, 456, 789),
+    )
+    @ddt.unpack
+    def test_create_verified_name_two_ids(
+        self, verification_attempt_id, proctored_exam_attempt_id, platform_verification_attempt_id
+    ):
         """
         Test that a verified name cannot be created with both a verification_attempt_id
         and a proctored_exam_attempt_id.
@@ -90,8 +101,9 @@ class TestVerifiedNameAPI(TestCase):
                 self.user,
                 self.VERIFIED_NAME,
                 self.PROFILE_NAME,
-                self.VERIFICATION_ATTEMPT_ID,
-                self.PROCTORED_EXAM_ATTEMPT_ID,
+                verification_attempt_id,
+                proctored_exam_attempt_id,
+                platform_verification_attempt_id,
             )
 
     @ddt.data(
@@ -202,65 +214,25 @@ class TestVerifiedNameAPI(TestCase):
         self.assertEqual(verified_name_qs[1].id, verified_name_first.id)
         self.assertEqual(verified_name_qs[0].id, verified_name_second.id)
 
-    def test_update_verification_attempt_id(self):
-        """
-        Test that the most recent VerifiedName is updated with a verification_attempt_id if
-        it does not already have one.
-        """
-        first_verified_name_id = self._create_verified_name().id
-        second_verified_name_id = self._create_verified_name().id
-
-        update_verification_attempt_id(self.user, self.VERIFICATION_ATTEMPT_ID)
-
-        first_verified_name_obj = VerifiedName.objects.get(id=first_verified_name_id)
-        second_verified_name_obj = VerifiedName.objects.get(id=second_verified_name_id)
-
-        self.assertIsNone(first_verified_name_obj.verification_attempt_id)
-        self.assertEqual(second_verified_name_obj.verification_attempt_id, self.VERIFICATION_ATTEMPT_ID)
-
     @ddt.data(
-        (VERIFICATION_ATTEMPT_ID, None),
-        (None, PROCTORED_EXAM_ATTEMPT_ID),
-    )
-    @ddt.unpack
-    def test_update_verification_attempt_id_already_exists(
-        self, verification_attempt_id, proctored_exam_attempt_id,
-    ):
-        """
-        Test that if the most recent VerifiedName already has a linked verification or
-        proctored exam attempt, a new VerifiedName will be created when updating the
-        `verification_attempt_id`.
-        """
-        self._create_verified_name(
-            verification_attempt_id=verification_attempt_id,
-            proctored_exam_attempt_id=proctored_exam_attempt_id,
-        )
-        update_verification_attempt_id(self.user, 789)
-        verified_name_qs = VerifiedName.objects.all()
-        self.assertEqual(len(verified_name_qs), 2)
-
-    def test_update_verification_attempt_id_none_exist(self):
-        """
-        Test that if the user does not have an existing VerifiedName,
-        `update_verification_attempt_id` will raise an exception.
-        """
-        with self.assertRaises(VerifiedNameDoesNotExist):
-            update_verification_attempt_id(self.user, self.VERIFICATION_ATTEMPT_ID)
-
-    @ddt.data(
-        (VERIFICATION_ATTEMPT_ID, None),
-        (None, PROCTORED_EXAM_ATTEMPT_ID)
+        (VERIFICATION_ATTEMPT_ID, None, None),
+        (None, PROCTORED_EXAM_ATTEMPT_ID, None),
+        (None, None, PLATFORM_VERIFICATION_ATTEMPT_ID)
     )
     @ddt.unpack
     def test_update_is_verified_status(
-        self, verification_attempt_id, proctored_exam_attempt_id,
+        self, verification_attempt_id, proctored_exam_attempt_id, platform_verification_attempt_id,
     ):
         """
         Test that VerifiedName status can be updated with a given attempt ID.
         """
-        self._create_verified_name(verification_attempt_id, proctored_exam_attempt_id)
+        self._create_verified_name(verification_attempt_id, proctored_exam_attempt_id, platform_verification_attempt_id)
         update_verified_name_status(
-            self.user, VerifiedNameStatus.DENIED, verification_attempt_id, proctored_exam_attempt_id,
+            self.user,
+            VerifiedNameStatus.DENIED,
+            verification_attempt_id,
+            proctored_exam_attempt_id,
+            platform_verification_attempt_id,
         )
         verified_name_obj = get_verified_name(self.user)
         self.assertEqual(VerifiedNameStatus.DENIED.value, verified_name_obj.status)
@@ -273,14 +245,23 @@ class TestVerifiedNameAPI(TestCase):
         with self.assertRaises(VerifiedNameAttemptIdNotGiven):
             update_verified_name_status(self.user, True)
 
-    def test_update_is_verified_multiple_attempt_ids(self):
+    @ddt.data(
+        (123, 456, None),
+        (123, None, 789),
+        (None, 456, 789),
+        (123, 456, 789),
+    )
+    @ddt.unpack
+    def test_update_is_verified_multiple_attempt_ids(
+        self, verification_attempt_id, proctored_exam_attempt_id, platform_verification_attempt_id
+    ):
         """
         Test that `update_is_verified_by_attempt_id` will raise an exception with multiple attempt
         IDs given.
         """
         with self.assertRaises(VerifiedNameMultipleAttemptIds):
             update_verified_name_status(
-                self.user, True, self.VERIFICATION_ATTEMPT_ID, self.PROCTORED_EXAM_ATTEMPT_ID,
+                self.user, True, verification_attempt_id, proctored_exam_attempt_id, platform_verification_attempt_id,
             )
 
     def test_update_is_verified_does_not_exist(self):
@@ -292,14 +273,15 @@ class TestVerifiedNameAPI(TestCase):
             update_verified_name_status(self.user, True, self.VERIFICATION_ATTEMPT_ID)
 
     def _create_verified_name(
-        self, verification_attempt_id=None, proctored_exam_attempt_id=None, status=VerifiedNameStatus.PENDING,
+        self, verification_attempt_id=None, proctored_exam_attempt_id=None,
+        platform_verification_attempt_id=None, status=VerifiedNameStatus.PENDING,
     ):
         """
         Util to create and return a VerifiedName with default names.
         """
         create_verified_name(
             self.user, self.VERIFIED_NAME, self.PROFILE_NAME, verification_attempt_id,
-            proctored_exam_attempt_id, status
+            proctored_exam_attempt_id, platform_verification_attempt_id, status
         )
         return get_verified_name(self.user)
 

--- a/edx_name_affirmation/tests/test_models.py
+++ b/edx_name_affirmation/tests/test_models.py
@@ -67,6 +67,22 @@ class VerifiedNameModelTests(TestCase):
         self.verified_name.verification_attempt_id = self.idv_attempt_id
         assert self.verified_name.verification_attempt_status is self.idv_attempt_status
 
+    @patch('edx_name_affirmation.models.PlatformVerificationAttempt')
+    def test_platform_verification_attempt_status(self, platform_attempt_mock):
+        """
+        Test that the platform verification status is updated as expected
+        """
+
+        idv_attempt_id_notfound_status = None
+
+        platform_attempt_mock.objects.get = self._mocked_model_get
+
+        self.verified_name.platform_verification_attempt_id = self.idv_attempt_id_notfound
+        assert self.verified_name.platform_verification_attempt_status is idv_attempt_id_notfound_status
+
+        self.verified_name.platform_verification_attempt_id = self.idv_attempt_id
+        assert self.verified_name.platform_verification_attempt_status is self.idv_attempt_status
+
     def test_verification_id_exclusivity(self):
         """
         Test that only one verification ID can be set at a time
@@ -84,7 +100,9 @@ class VerifiedNameModelTests(TestCase):
         return type('obj', (object,), dictionary)
 
     def _mocked_model_get(self, id):  # pylint: disable=redefined-builtin
-        "Helper method to mock the behavior of SoftwareSecurePhotoVerification model. Used to mock below."
+        """
+        Helper method to mock the behavior of SoftwareSecurePhotoVerification and PlatformVerificationAttempt models.
+        """
         if id == self.idv_attempt_id_notfound:
             raise ObjectDoesNotExist
 

--- a/edx_name_affirmation/tests/test_views.py
+++ b/edx_name_affirmation/tests/test_views.py
@@ -329,7 +329,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
 
     def _create_verified_name(
         self, user, verification_attempt_id=None,
-        proctored_exam_attempt_id=None, status=VerifiedNameStatus.PENDING,
+        proctored_exam_attempt_id=None, platform_verification_attempt_id=None, status=VerifiedNameStatus.PENDING,
     ):
         """
         Create and return a verified name object.
@@ -340,6 +340,7 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             self.PROFILE_NAME,
             verification_attempt_id,
             proctored_exam_attempt_id,
+            platform_verification_attempt_id,
             status
         )
         return get_verified_name(user)
@@ -362,6 +363,8 @@ class VerifiedNameViewTests(NameAffirmationViewsTestCase):
             'proctored_exam_attempt_id': verified_name_obj.proctored_exam_attempt_id,
             'status': verified_name_obj.status,
             'use_verified_name_for_certs': use_verified_name_for_certs,
+            'platform_verification_attempt_id': verified_name_obj.platform_verification_attempt_id,
+            'platform_verification_attempt_status': None,
         }
 
 
@@ -479,7 +482,9 @@ class VerifiedNameHistoryViewTests(NameAffirmationViewsTestCase):
                 'verification_attempt_id': verified_name_obj.verification_attempt_id,
                 'verification_attempt_status': None,
                 'proctored_exam_attempt_id': verified_name_obj.proctored_exam_attempt_id,
-                'status': verified_name_obj.status
+                'status': verified_name_obj.status,
+                'platform_verification_attempt_id': verified_name_obj.platform_verification_attempt_id,
+                'platform_verification_attempt_status': None,
             }
             expected_response['results'].append(data)
 

--- a/edx_name_affirmation/views.py
+++ b/edx_name_affirmation/views.py
@@ -111,6 +111,7 @@ class VerifiedNameView(AuthenticatedAPIView):
             "profile_name": "Jon Doe"
             "verification_attempt_id": (Optional)
             "proctored_exam_attempt_id": (Optional)
+            "platform_verification_attempt_id": (Optional)
             "status": (Optional)
         }
         """
@@ -131,6 +132,7 @@ class VerifiedNameView(AuthenticatedAPIView):
                     request.data.get('profile_name'),
                     verification_attempt_id=request.data.get('verification_attempt_id', None),
                     proctored_exam_attempt_id=request.data.get('proctored_exam_attempt_id', None),
+                    platform_verification_attempt_id=request.data.get('platform_verification_attempt_id', None),
                     status=request.data.get('status', VerifiedNameStatus.PENDING)
                 )
                 response_status = http_status.HTTP_200_OK


### PR DESCRIPTION
**Description:**

This PR integrates the newly added `platform_verification_attempt_id` field into the name affirmation code.

**JIRA:**

[COSMO-495](https://2u-internal.atlassian.net/browse/COSMO-495)

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [ ] Described your changes in `CHANGELOG.rst`.
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
