### PR TITLE
chore: added sphinx dependencies in constraint file

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ billiard==4.2.0
     # via celery
 celery==5.4.0
     # via
-    #   -c requirements/constraints.txt
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/constraints.txt
     #   edx-celeryutils
 certifi==2024.8.30
     # via requests
@@ -44,7 +44,7 @@ cryptography==43.0.1
     # via pyjwt
 django==4.2.16
     # via
-    #   -c requirements/common_constraints.txt
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/common_constraints.txt
     #   -r requirements/base.in
     #   django-config-models
     #   django-crum
@@ -72,7 +72,7 @@ django-model-utils==5.0.0
     #   edx-celeryutils
 django-simple-history==3.4.0
     # via
-    #   -c requirements/constraints.txt
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/constraints.txt
     #   -r requirements/base.in
 django-waffle==4.1.0
     # via

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -12,7 +12,6 @@
 # Note: Changes to this file will automatically be used by other repos, referencing
 #  this file from Github directly. It does not require packaging in edx-lint.
 
-
 # using LTS django version
 Django<5.0
 
@@ -24,9 +23,6 @@ elasticsearch<7.14.0
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 
 
-# Cause: https://github.com/openedx/event-tracking/pull/290
-# event-tracking 2.4.1 upgrades to pymongo 4.4.0 which is not supported on edx-platform.
-# We will pin event-tracking to do not break existing installations
-# This can be unpinned once https://github.com/openedx/edx-platform/issues/34586
-# has been resolved and edx-platform is running with pymongo>=4.4.0
-event-tracking<2.4.1
+# Cause: https://github.com/openedx/edx-lint/issues/458
+# This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
+pip<24.3

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,5 +17,14 @@ celery>=5.2.2,<6.0.0
 
 django-simple-history==3.4.0
 
+# docutils has conflicting version for the dependencies. Reference issue: https://github.com/edx/edx-name-affirmation/issues/231
+# issue to unpin
+# Date: 09-12-2024
+
+sphinx==8.1.3
+sphinx-book-theme==1.1.3
+docutils==0.21.2
+sphinxcontrib-applehelp==2.0.0
+
 # Temporary to Support the python 3.11 Upgrade
 backports.zoneinfo;python_version<"3.9"  # Newer versions have zoneinfo available in the standard library

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,50 +6,46 @@
 #
 annotated-types==0.7.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   pydantic
 asgiref==3.8.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   django
 astroid==3.2.4
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   pylint
     #   pylint-celery
 backports-tarfile==1.2.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   jaraco-context
 build==1.2.1
     # via
-    #   -r requirements/pip-tools.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/pip-tools.txt
     #   pip-tools
 cachetools==5.5.0
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/ci.txt
     #   tox
 certifi==2024.8.30
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   requests
-cffi==1.17.1
-    # via
-    #   -r requirements/quality.txt
-    #   cryptography
 chardet==5.2.0
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/ci.txt
     #   diff-cover
     #   tox
 charset-normalizer==3.3.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   requests
 click==8.1.7
     # via
-    #   -r requirements/pip-tools.txt
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/pip-tools.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   click-log
     #   code-annotations
     #   edx-lint
@@ -57,89 +53,81 @@ click==8.1.7
     #   typer
 click-log==0.4.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   edx-lint
 code-annotations==1.8.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   edx-lint
 colorama==0.4.6
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/ci.txt
     #   tox
 coverage==7.6.1
-    # via -r requirements/ci.txt
-cryptography==43.0.1
-    # via
-    #   -r requirements/quality.txt
-    #   secretstorage
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/ci.txt
 diff-cover==9.1.1
     # via -r requirements/dev.in
 dill==0.3.8
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   pylint
 distlib==0.3.8
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/ci.txt
     #   virtualenv
 django==4.2.16
     # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/quality.txt
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/common_constraints.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   edx-i18n-tools
 docutils==0.21.2
     # via
-    #   -r requirements/quality.txt
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/constraints.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   readme-renderer
     #   rstcheck-core
 edx-i18n-tools==1.6.3
     # via -r requirements/dev.in
 edx-lint==5.4.0
-    # via -r requirements/quality.txt
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
 filelock==3.15.4
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/ci.txt
     #   tox
     #   virtualenv
 idna==3.8
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   requests
 importlib-metadata==8.4.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   keyring
     #   twine
 isort==5.13.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   pylint
 jaraco-classes==3.4.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   keyring
 jaraco-context==6.0.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   keyring
 jaraco-functools==4.0.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   code-annotations
     #   diff-cover
 keyring==25.3.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   twine
 lxml[html-clean,html_clean]==5.3.0
     # via
@@ -149,33 +137,33 @@ lxml-html-clean==0.3.1
     # via lxml
 markdown-it-py==3.0.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   rich
 markupsafe==2.1.5
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   jinja2
 mccabe==0.7.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   pylint
 mdurl==0.1.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   markdown-it-py
 more-itertools==10.5.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   jaraco-classes
     #   jaraco-functools
 nh3==0.2.18
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   readme-renderer
 packaging==24.1
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/pip-tools.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/ci.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/pip-tools.txt
     #   build
     #   pyproject-api
     #   tox
@@ -183,182 +171,174 @@ path==16.16.0
     # via edx-i18n-tools
 pbr==6.1.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   stevedore
 pip-tools==7.4.1
-    # via -r requirements/pip-tools.txt
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/pip-tools.txt
 pkginfo==1.10.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   twine
 platformdirs==4.2.2
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/ci.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   pylint
     #   tox
     #   virtualenv
 pluggy==1.5.0
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/ci.txt
     #   diff-cover
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
 pycodestyle==2.12.1
-    # via -r requirements/quality.txt
-pycparser==2.22
-    # via
-    #   -r requirements/quality.txt
-    #   cffi
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
 pydantic==2.9.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   rstcheck-core
 pydantic-core==2.23.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   pydantic
 pydocstyle==6.3.0
-    # via -r requirements/quality.txt
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
 pygments==2.18.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   diff-cover
     #   readme-renderer
     #   rich
 pylint==3.2.7
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   edx-lint
 pylint-django==2.5.5
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   edx-lint
 pylint-plugin-utils==0.8.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   pylint-celery
     #   pylint-django
 pyproject-api==1.7.1
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/ci.txt
     #   tox
 pyproject-hooks==1.1.0
     # via
-    #   -r requirements/pip-tools.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/pip-tools.txt
     #   build
     #   pip-tools
 python-slugify==8.0.4
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   code-annotations
 pyyaml==6.0.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   code-annotations
     #   edx-i18n-tools
 readme-renderer==44.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   twine
 requests==2.32.3
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   requests-toolbelt
     #   twine
 requests-toolbelt==1.0.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   twine
 rfc3986==2.0.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   twine
 rich==13.8.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   twine
     #   typer
 rstcheck==6.2.4
-    # via -r requirements/quality.txt
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
 rstcheck-core==1.2.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   rstcheck
-secretstorage==3.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 shellingham==1.5.4
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   typer
 six==1.16.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   edx-lint
 snowballstemmer==2.2.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   pydocstyle
 sqlparse==0.5.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   django
 stevedore==5.3.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   code-annotations
 text-unidecode==1.3
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   python-slugify
 tomlkit==0.13.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   pylint
 tox==4.18.0
-    # via -r requirements/ci.txt
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/ci.txt
 twine==5.1.1
-    # via -r requirements/quality.txt
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
 typer==0.12.5
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   rstcheck
 typing-extensions==4.12.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   pydantic
     #   pydantic-core
     #   typer
 tzdata==2024.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   pydantic
 urllib3==2.2.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   requests
     #   twine
 virtualenv==20.26.3
     # via
-    #   -r requirements/ci.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/ci.txt
     #   tox
 wheel==0.44.0
     # via
-    #   -r requirements/pip-tools.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/pip-tools.txt
     #   pip-tools
 zipp==3.20.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/quality.txt
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -15,12 +15,16 @@ asgiref==3.8.1
 attrs==24.2.0
     # via openedx-events
 babel==2.16.0
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+beautifulsoup4==4.12.3
+    # via pydata-sphinx-theme
 billiard==4.2.0
     # via celery
 celery==5.4.0
     # via
-    #   -c requirements/constraints.txt
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/constraints.txt
     #   edx-celeryutils
 certifi==2024.8.30
     # via requests
@@ -50,8 +54,8 @@ cryptography==43.0.1
     # via pyjwt
 django==4.2.16
     # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/base.in
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/common_constraints.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.in
     #   django-config-models
     #   django-crum
     #   django-model-utils
@@ -67,19 +71,19 @@ django==4.2.16
     #   jsonfield
     #   openedx-events
 django-config-models==2.7.0
-    # via -r requirements/base.in
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.in
 django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-toggles
 django-model-utils==5.0.0
     # via
-    #   -r requirements/base.in
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.in
     #   edx-celeryutils
 django-simple-history==3.4.0
     # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/constraints.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.in
 django-waffle==4.1.0
     # via
     #   edx-django-utils
@@ -87,7 +91,7 @@ django-waffle==4.1.0
     #   edx-toggles
 djangorestframework==3.15.2
     # via
-    #   -r requirements/base.in
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.in
     #   django-config-models
     #   drf-jwt
     #   drf-yasg
@@ -99,6 +103,7 @@ doc8==1.1.2
     # via -r requirements/doc.in
 docutils==0.21.2
     # via
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/constraints.txt
     #   doc8
     #   pydata-sphinx-theme
     #   readme-renderer
@@ -109,24 +114,27 @@ drf-jwt==1.19.2
 drf-yasg==1.21.7
     # via edx-api-doc-tools
 edx-api-doc-tools==1.8.0
-    # via -r requirements/base.in
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.in
 edx-ccx-keys==1.3.0
     # via openedx-events
 edx-celeryutils==1.3.0
-    # via -r requirements/base.in
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.in
 edx-django-utils==5.15.0
     # via
-    #   -r requirements/base.in
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.in
     #   django-config-models
     #   edx-drf-extensions
     #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.4.0
-    # via -r requirements/base.in
-edx-opaque-keys==2.11.0
-    # via edx-drf-extensions
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.in
+edx-opaque-keys[django]==2.11.0
+    # via
+    #   edx-ccx-keys
+    #   edx-drf-extensions
+    #   openedx-events
 edx-toggles==5.2.0
-    # via -r requirements/base.in
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.in
 fastavro==1.9.7
     # via openedx-events
 idna==3.8
@@ -150,11 +158,10 @@ newrelic==9.13.0
 nh3==0.2.18
     # via readme-renderer
 openedx-events==9.14.1
-    # via -r requirements/base.in
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.in
 packaging==24.1
     # via
     #   drf-yasg
-    #   pydata-sphinx-theme
     #   sphinx
 pbr==6.1.0
     # via stevedore
@@ -166,7 +173,7 @@ psutil==6.0.0
     # via edx-django-utils
 pycparser==2.22
     # via cffi
-pydata-sphinx-theme==0.14.4
+pydata-sphinx-theme==0.16.0
     # via sphinx-book-theme
 pygments==2.18.0
     # via
@@ -205,6 +212,7 @@ semantic-version==2.10.0
     # via edx-drf-extensions
 six==1.16.0
     # via
+    #   edx-ccx-keys
     #   pockets
     #   python-dateutil
     #   sphinxcontrib-napoleon
@@ -212,15 +220,20 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==5.3.0
+sphinx==8.1.3
     # via
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/constraints.txt
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-sphinx-book-theme==1.0.1
-    # via -r requirements/doc.in
-sphinxcontrib-applehelp==1.0.4
-    # via sphinx
+sphinx-book-theme==1.1.3
+    # via
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/constraints.txt
+    #   -r requirements/doc.in
+sphinxcontrib-applehelp==2.0.0
+    # via
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/constraints.txt
+    #   sphinx
 sphinxcontrib-devhelp==2.0.0
     # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
@@ -245,11 +258,8 @@ text-unidecode==1.3
     # via python-slugify
 typing-extensions==4.12.2
     # via
-    #   asgiref
     #   edx-opaque-keys
-    #   kombu
     #   pydata-sphinx-theme
-    # via edx-opaque-keys
 tzdata==2024.1
     # via celery
 uritemplate==4.1.1
@@ -263,6 +273,3 @@ vine==5.1.0
     #   kombu
 wcwidth==0.2.13
     # via prompt-toolkit
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,8 +16,6 @@ backports-tarfile==1.2.0
     # via jaraco-context
 certifi==2024.8.30
     # via requests
-cffi==1.17.1
-    # via cryptography
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
@@ -30,16 +28,15 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.8.0
     # via edx-lint
-cryptography==43.0.1
-    # via secretstorage
 dill==0.3.8
     # via pylint
 django==4.2.16
     # via
-    #   -c requirements/common_constraints.txt
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/common_constraints.txt
     #   -r requirements/quality.in
 docutils==0.21.2
     # via
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/constraints.txt
     #   readme-renderer
     #   rstcheck-core
 edx-lint==5.4.0
@@ -60,10 +57,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.0.2
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via code-annotations
 keyring==25.3.0
@@ -90,8 +83,6 @@ platformdirs==4.2.2
     # via pylint
 pycodestyle==2.12.1
     # via -r requirements/quality.in
-pycparser==2.22
-    # via cffi
 pydantic==2.9.0
     # via rstcheck-core
 pydantic-core==2.23.2
@@ -138,8 +129,6 @@ rstcheck==6.2.4
     # via -r requirements/quality.in
 rstcheck-core==1.2.1
     # via rstcheck
-secretstorage==3.3.3
-    # via keyring
 shellingham==1.5.4
     # via typer
 six==1.16.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,41 +6,41 @@
 #
 amqp==5.2.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   kombu
 asgiref==3.8.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   django
 attrs==24.2.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   openedx-events
 billiard==4.2.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   celery
 celery==5.4.0
     # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/constraints.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-celeryutils
 certifi==2024.8.30
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   requests
 click==8.1.7
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -49,32 +49,32 @@ click==8.1.7
     #   edx-django-utils
 click-didyoumean==0.3.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   celery
 code-annotations==1.8.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   -r requirements/test.in
     #   edx-toggles
 coverage[toml]==7.6.1
     # via pytest-cov
 cryptography==43.0.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   pyjwt
 ddt==1.7.2
     # via -r requirements/test.in
     # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/base.txt
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/common_constraints.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   django-config-models
     #   django-crum
     #   django-model-utils
@@ -90,29 +90,29 @@ ddt==1.7.2
     #   jsonfield
     #   openedx-events
 django-config-models==2.7.0
-    # via -r requirements/base.txt
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
 django-crum==0.7.9
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-django-utils
     #   edx-toggles
 django-model-utils==5.0.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-celeryutils
 django-simple-history==3.4.0
     # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+    #   -c /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/constraints.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
 django-waffle==4.1.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
 djangorestframework==3.15.2
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   django-config-models
     #   drf-jwt
     #   drf-yasg
@@ -120,114 +120,114 @@ djangorestframework==3.15.2
     #   edx-drf-extensions
 dnspython==2.6.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   pymongo
 drf-jwt==1.19.2
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-drf-extensions
 drf-yasg==1.21.7
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-api-doc-tools
 edx-api-doc-tools==1.8.0
-    # via -r requirements/base.txt
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
 edx-ccx-keys==1.3.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   openedx-events
 edx-celeryutils==1.3.0
-    # via -r requirements/base.txt
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
 edx-django-utils==5.15.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   django-config-models
     #   edx-drf-extensions
     #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.4.0
-    # via -r requirements/base.txt
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
 edx-opaque-keys[django]==2.11.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-toggles==5.2.0
-    # via -r requirements/base.txt
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
 fastavro==1.9.7
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   openedx-events
 idna==3.8
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   requests
 inflection==0.5.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   drf-yasg
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.4
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   code-annotations
 jsonfield==3.1.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-celeryutils
 kombu==5.4.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   celery
 markupsafe==2.1.5
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   jinja2
 mock==5.1.0
     # via -r requirements/test.in
 newrelic==9.13.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-django-utils
 openedx-events==9.14.1
-    # via -r requirements/base.txt
+    # via -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
 packaging==24.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   drf-yasg
     #   pytest
 pbr==6.1.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   stevedore
 pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.47
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   click-repl
 psutil==6.0.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-django-utils
 pycparser==2.22
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   cffi
 pyjwt[crypto]==2.9.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   drf-jwt
     #   edx-drf-extensions
 pymongo==4.8.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-django-utils
 pytest==8.3.2
     # via
@@ -239,71 +239,71 @@ pytest-django==4.9.0
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   celery
 python-slugify==8.0.4
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   code-annotations
 pytz==2024.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   drf-yasg
 pyyaml==6.0.2
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   code-annotations
     #   drf-yasg
 requests==2.32.3
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-drf-extensions
 semantic-version==2.10.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-drf-extensions
 six==1.16.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-ccx-keys
     #   python-dateutil
 sqlparse==0.5.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   django
 stevedore==5.3.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   python-slugify
 typing-extensions==4.12.2
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   edx-opaque-keys
 tzdata==2024.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   celery
 uritemplate==4.1.1
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   drf-yasg
 urllib3==2.2.2
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   requests
 vine==5.1.0
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.2.13
     # via
-    #   -r requirements/base.txt
+    #   -r /Users/hunia.fatima/Desktop/edX/edx-name-affirmation/requirements/base.txt
     #   prompt-toolkit


### PR DESCRIPTION
**Description:**
Following dependencies had conflict on docutils version. 
- doc8 
- readme-renderer
- sphinx

This PR addresses that conflict


**Issue Link**

https://github.com/edx/edx-name-affirmation/issues/231

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [ ] Described your changes in `CHANGELOG.rst`.
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
