### PR TITLE
fix: attempting to debug requirements workflow

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -15,7 +15,6 @@ jobs:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
       branch: ${{ github.event.inputs.branch || 'main' }}
-      python_version: "3.11"
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
       # team_reviewers: ""


### PR DESCRIPTION
**Description:**

The python requirements upgrade workflow is currently failing (see https://github.com/edx/edx-name-affirmation/actions/runs/12272970013/job/34382900297). Attempting to remove the specified python version, as is done in a few other repos, to see if this helps.

