### PR TITLE
fix: manually upgrade requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ cffi==1.17.1
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
+click==8.1.8
     # via
     #   celery
     #   click-didyoumean

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,10 +17,6 @@ astroid==3.2.4
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-backports-tarfile==1.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   jaraco-context
 build==1.2.2.post1
     # via
     #   -r requirements/pip-tools.txt
@@ -33,10 +29,6 @@ certifi==2024.8.30
     # via
     #   -r requirements/quality.txt
     #   requests
-cffi==1.17.1
-    # via
-    #   -r requirements/quality.txt
-    #   cryptography
 chardet==5.2.0
     # via
     #   -r requirements/ci.txt
@@ -46,7 +38,7 @@ charset-normalizer==3.3.2
     # via
     #   -r requirements/quality.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -69,10 +61,6 @@ colorama==0.4.6
     #   tox
 coverage==7.6.1
     # via -r requirements/ci.txt
-cryptography==44.0.0
-    # via
-    #   -r requirements/quality.txt
-    #   secretstorage
 diff-cover==9.1.1
     # via -r requirements/dev.in
 dill==0.3.8
@@ -110,7 +98,6 @@ idna==3.8
 importlib-metadata==8.4.0
     # via
     #   -r requirements/quality.txt
-    #   keyring
     #   twine
 isort==5.13.2
     # via
@@ -128,11 +115,6 @@ jaraco-functools==4.0.2
     # via
     #   -r requirements/quality.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via
     #   -r requirements/quality.txt
@@ -208,10 +190,6 @@ polib==1.2.0
     # via edx-i18n-tools
 pycodestyle==2.12.1
     # via -r requirements/quality.txt
-pycparser==2.22
-    # via
-    #   -r requirements/quality.txt
-    #   cffi
 pydantic==2.9.0
     # via
     #   -r requirements/quality.txt
@@ -294,10 +272,6 @@ rstcheck-core==1.2.1
     # via
     #   -r requirements/quality.txt
     #   rstcheck
-secretstorage==3.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 shellingham==1.5.4
     # via
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -34,7 +34,7 @@ cffi==1.17.1
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
+click==8.1.8
     # via
     #   celery
     #   click-didyoumean

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,7 +6,7 @@
 #
 build==1.2.2.post1
     # via pip-tools
-click==8.1.7
+click==8.1.8
     # via pip-tools
 packaging==24.2
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/edx-name-affirmation/edx-name-affirmation/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==75.6.0
+setuptools==75.8.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,15 +12,11 @@ astroid==3.2.4
     # via
     #   pylint
     #   pylint-celery
-backports-tarfile==1.2.0
-    # via jaraco-context
 certifi==2024.8.30
     # via requests
-cffi==1.17.1
-    # via cryptography
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
+click==8.1.8
     # via
     #   click-log
     #   code-annotations
@@ -30,8 +26,6 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.8.0
     # via edx-lint
-cryptography==44.0.0
-    # via secretstorage
 dill==0.3.8
     # via pylint
 django==4.2.16
@@ -48,9 +42,7 @@ edx-lint==5.4.0
 idna==3.8
     # via requests
 importlib-metadata==8.4.0
-    # via
-    #   keyring
-    #   twine
+    # via twine
 isort==5.13.2
     # via
     #   -r requirements/quality.in
@@ -61,10 +53,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.0.2
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via code-annotations
 keyring==25.3.0
@@ -91,8 +79,6 @@ platformdirs==4.2.2
     # via pylint
 pycodestyle==2.12.1
     # via -r requirements/quality.in
-pycparser==2.22
-    # via cffi
 pydantic==2.9.0
     # via rstcheck-core
 pydantic-core==2.23.2
@@ -139,8 +125,6 @@ rstcheck==6.2.4
     # via -r requirements/quality.in
 rstcheck-core==1.2.1
     # via rstcheck
-secretstorage==3.3.3
-    # via keyring
 shellingham==1.5.4
     # via typer
 six==1.16.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -38,7 +38,7 @@ charset-normalizer==3.3.2
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -r requirements/base.txt
     #   celery


### PR DESCRIPTION
**Description:**

Click version 8.1.7 was causing issues with compiling requirements. Manually upgrading to 8.1.8, and verified that the `make upgrade` and `make requirements` commands still work.

**Pre-Merge Checklist:**

- [ ] Updated the version number in `edx_name_affirmation/__init__.py` if these changes are to be released. See [OEP-47: Semantic Versioning](https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.html).
- [ ] Described your changes in `CHANGELOG.rst`.
- [ ] Confirmed Github reports all automated tests/checks are passing.
- [ ] Approved by at least one additional reviewer.

**Post-Merge:**

- [ ] Create a tag matching the new version number.
