### PR TITLE
Remove django simple history constraint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: ["3.11"]
         node-version: ["10"]
         toxenv: [django42, quality, pii_check, rst_validation]

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Setup python

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.0.2]
+~~~~~~~~~~~~~~~~~~~~
+* Upgrade django-simple-history to latest version
+* Pin click and packaging version to fix upgrade failure
+
 [3.0.1] - 2024-10-07
 ~~~~~~~~~~~~~~~~~~~~
 * Upgrade django-simple-history and add migration to match the new version.

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,6 @@ $(COMMON_CONSTRAINTS_TXT):
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: $(COMMON_CONSTRAINTS_TXT)
-	sed 's/django-simple-history==3.0.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
-	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	pip install -qr requirements/pip-tools.txt
 	pip-compile --rebuild --upgrade --allow-unsafe -o requirements/pip.txt requirements/pip.in
 	pip-compile --rebuild --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in

--- a/edx_name_affirmation/__init__.py
+++ b/edx_name_affirmation/__init__.py
@@ -2,4 +2,4 @@
 Django app housing name affirmation logic.
 """
 
-__version__ = '3.0.1'
+__version__ = '3.0.2'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,7 +5,9 @@ Django>=2.2              # Web application framework
 django-config-models
 django-model-utils       # Provides TimeStampedModel abstract base class
 djangorestframework
-django-simple-history    # Provides historical records on models
+# For some reason, pip is not fetching latest version so adding a min. constraint 
+# edx-platform needs this dependency bump to upgrade django-simple-history in requirements
+django-simple-history>3.10.0
 
 edx-api-doc-tools        # Doc tools to generate swagger docs for APIs
 edx-celeryutils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -73,9 +73,7 @@ django-model-utils==5.0.0
     #   -r requirements/base.in
     #   edx-celeryutils
 django-simple-history==3.10.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+    # via -r requirements/base.in
 django-waffle==4.1.0
     # via
     #   edx-django-utils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,6 +26,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.8
     # via
+    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -49,6 +50,7 @@ django==4.2.16
     #   django-config-models
     #   django-crum
     #   django-model-utils
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
@@ -70,7 +72,7 @@ django-model-utils==5.0.0
     # via
     #   -r requirements/base.in
     #   edx-celeryutils
-django-simple-history==3.4.0
+django-simple-history==3.10.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -134,7 +136,9 @@ newrelic==9.13.0
 openedx-events==9.14.1
     # via -r requirements/base.in
 packaging==24.2
-    # via drf-yasg
+    # via
+    #   -c requirements/constraints.txt
+    #   drf-yasg
 pbr==6.1.0
     # via stevedore
 prompt-toolkit==3.0.47
@@ -185,9 +189,7 @@ tzdata==2024.1
 uritemplate==4.1.1
     # via drf-yasg
 urllib3==2.2.2
-    # via
-    #   -c requirements/common_constraints.txt
-    #   requests
+    # via requests
 vine==5.1.0
     # via
     #   amqp

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -20,6 +20,7 @@ filelock==3.15.4
     #   virtualenv
 packaging==24.2
     # via
+    #   -c requirements/constraints.txt
     #   pyproject-api
     #   tox
 platformdirs==4.2.2

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -20,13 +20,6 @@ Django<5.0
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
 
-# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
-
-
 # Cause: https://github.com/openedx/edx-lint/issues/458
 # This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
 pip<24.3
-
-# Cause: https://github.com/openedx/edx-lint/issues/475
-# This can be unpinned once https://github.com/openedx/edx-lint/issues/476 has been resolved.
-urllib3<2.3.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,6 +16,8 @@
 celery>=5.2.2,<6.0.0
 
 # click and packaging are pinned to avoid upgrade issues
+# Created follow up issue to unpin these https://github.com/edx/edx-name-affirmation/issues/256
+# Date: 27-08-2025
 click<8.2.0
 packaging<25.0
 
@@ -27,7 +29,3 @@ sphinx==8.1.3
 sphinx-book-theme==1.1.3
 docutils==0.21.2
 sphinxcontrib-applehelp==2.0.0
-
-# For some reason, pip is not fetching latest version so adding a min. constraint 
-# edx-platform needs this dependency bump to upgrade django-simple-history in requirements
-django-simple-history>3.10.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,7 +16,7 @@
 celery>=5.2.2,<6.0.0
 
 # click and packaging are pinned to avoid upgrade issues
-# Created follow up issue to unpin these https://github.com/edx/edx-name-affirmation/issues/256
+# Created follow up issue to unpin click and packaging: https://github.com/edx/edx-name-affirmation/issues/256
 # Date: 27-08-2025
 click<8.2.0
 packaging<25.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,7 +15,9 @@
 # the next major release, ensure the installed version is within boundaries.
 celery>=5.2.2,<6.0.0
 
-django-simple-history==3.4.0
+# click and packaging are pinned to avoid upgrade issues
+click<8.2.0
+packaging<25.0
 
 # docutils has conflicting version for the dependencies. Reference issue: https://github.com/edx/edx-name-affirmation/issues/231
 # issue to unpin
@@ -26,5 +28,6 @@ sphinx-book-theme==1.1.3
 docutils==0.21.2
 sphinxcontrib-applehelp==2.0.0
 
-# Temporary to Support the python 3.11 Upgrade
-backports.zoneinfo;python_version<"3.9"  # Newer versions have zoneinfo available in the standard library
+# For some reason, pip is not fetching latest version so adding a min. constraint 
+# edx-platform needs this dependency bump to upgrade django-simple-history in requirements
+django-simple-history>3.10.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ backports-tarfile==1.2.0
     # via
     #   -r requirements/quality.txt
     #   jaraco-context
-build==1.2.2.post1
+build==1.3.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
@@ -33,10 +33,6 @@ certifi==2024.8.30
     # via
     #   -r requirements/quality.txt
     #   requests
-cffi==1.17.1
-    # via
-    #   -r requirements/quality.txt
-    #   cryptography
 chardet==5.2.0
     # via
     #   -r requirements/ci.txt
@@ -48,6 +44,7 @@ charset-normalizer==3.3.2
     #   requests
 click==8.1.8
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   click-log
@@ -69,10 +66,6 @@ colorama==0.4.6
     #   tox
 coverage==7.6.1
     # via -r requirements/ci.txt
-cryptography==44.0.0
-    # via
-    #   -r requirements/quality.txt
-    #   secretstorage
 diff-cover==9.1.1
     # via -r requirements/dev.in
 dill==0.3.8
@@ -128,11 +121,6 @@ jaraco-functools==4.0.2
     # via
     #   -r requirements/quality.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via
     #   -r requirements/quality.txt
@@ -142,7 +130,7 @@ keyring==25.3.0
     # via
     #   -r requirements/quality.txt
     #   twine
-lxml[html-clean,html_clean]==5.3.0
+lxml[html-clean]==5.3.0
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
@@ -175,6 +163,7 @@ nh3==0.2.18
     #   readme-renderer
 packaging==24.2
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   build
@@ -186,7 +175,7 @@ pbr==6.1.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pip-tools==7.4.1
+pip-tools==7.5.0
     # via -r requirements/pip-tools.txt
 pkginfo==1.10.0
     # via
@@ -208,10 +197,6 @@ polib==1.2.0
     # via edx-i18n-tools
 pycodestyle==2.12.1
     # via -r requirements/quality.txt
-pycparser==2.22
-    # via
-    #   -r requirements/quality.txt
-    #   cffi
 pydantic==2.9.0
     # via
     #   -r requirements/quality.txt
@@ -294,10 +279,6 @@ rstcheck-core==1.2.1
     # via
     #   -r requirements/quality.txt
     #   rstcheck
-secretstorage==3.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 shellingham==1.5.4
     # via
     #   -r requirements/quality.txt
@@ -346,7 +327,6 @@ tzdata==2024.1
     #   pydantic
 urllib3==2.2.2
     # via
-    #   -c requirements/common_constraints.txt
     #   -r requirements/quality.txt
     #   requests
     #   twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -83,9 +83,7 @@ django-model-utils==5.0.0
     #   -r requirements/base.in
     #   edx-celeryutils
 django-simple-history==3.10.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+    # via -r requirements/base.in
 django-waffle==4.1.0
     # via
     #   edx-django-utils

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -36,6 +36,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.8
     # via
+    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -59,6 +60,7 @@ django==4.2.16
     #   django-config-models
     #   django-crum
     #   django-model-utils
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
@@ -80,7 +82,7 @@ django-model-utils==5.0.0
     # via
     #   -r requirements/base.in
     #   edx-celeryutils
-django-simple-history==3.4.0
+django-simple-history==3.10.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -161,6 +163,7 @@ openedx-events==9.14.1
     # via -r requirements/base.in
 packaging==24.2
     # via
+    #   -c requirements/constraints.txt
     #   drf-yasg
     #   sphinx
 pbr==6.1.0
@@ -265,9 +268,7 @@ tzdata==2024.1
 uritemplate==4.1.1
     # via drf-yasg
 urllib3==2.2.2
-    # via
-    #   -c requirements/common_constraints.txt
-    #   requests
+    # via requests
 vine==5.1.0
     # via
     #   amqp

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,17 @@
 #
 #    make upgrade
 #
-build==1.2.2.post1
+build==1.3.0
     # via pip-tools
 click==8.1.8
-    # via pip-tools
+    # via
+    #   -c requirements/constraints.txt
+    #   pip-tools
 packaging==24.2
-    # via build
-pip-tools==7.4.1
+    # via
+    #   -c requirements/constraints.txt
+    #   build
+pip-tools==7.5.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/edx-name-affirmation/edx-name-affirmation/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==78.1.0
+setuptools==80.9.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,12 +16,11 @@ backports-tarfile==1.2.0
     # via jaraco-context
 certifi==2024.8.30
     # via requests
-cffi==1.17.1
-    # via cryptography
 charset-normalizer==3.3.2
     # via requests
 click==8.1.8
     # via
+    #   -c requirements/constraints.txt
     #   click-log
     #   code-annotations
     #   edx-lint
@@ -30,8 +29,6 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.8.0
     # via edx-lint
-cryptography==44.0.0
-    # via secretstorage
 dill==0.3.8
     # via pylint
 django==4.2.16
@@ -61,10 +58,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.0.2
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via code-annotations
 keyring==25.3.0
@@ -91,8 +84,6 @@ platformdirs==4.2.2
     # via pylint
 pycodestyle==2.12.1
     # via -r requirements/quality.in
-pycparser==2.22
-    # via cffi
 pydantic==2.9.0
     # via rstcheck-core
 pydantic-core==2.23.2
@@ -139,8 +130,6 @@ rstcheck==6.2.4
     # via -r requirements/quality.in
 rstcheck-core==1.2.1
     # via rstcheck
-secretstorage==3.3.3
-    # via keyring
 shellingham==1.5.4
     # via typer
 six==1.16.0
@@ -168,7 +157,6 @@ tzdata==2024.1
     # via pydantic
 urllib3==2.2.2
     # via
-    #   -c requirements/common_constraints.txt
     #   requests
     #   twine
 zipp==3.20.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -103,9 +103,7 @@ django-model-utils==5.0.0
     #   -r requirements/base.txt
     #   edx-celeryutils
 django-simple-history==3.10.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+    # via -r requirements/base.txt
 django-waffle==4.1.0
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -40,6 +40,7 @@ charset-normalizer==3.3.2
     #   requests
 click==8.1.8
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   celery
     #   click-didyoumean
@@ -78,6 +79,7 @@ ddt==1.7.2
     #   django-config-models
     #   django-crum
     #   django-model-utils
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
@@ -100,7 +102,7 @@ django-model-utils==5.0.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
-django-simple-history==3.4.0
+django-simple-history==3.10.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -195,6 +197,7 @@ openedx-events==9.14.1
     # via -r requirements/base.txt
 packaging==24.2
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   drf-yasg
     #   pytest
@@ -295,7 +298,6 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==2.2.2
     # via
-    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   requests
 vine==5.1.0

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.11',
     ],
     packages=[


### PR DESCRIPTION
## Description
- Remove `django-simple-history` constraint to allow upgrading the history package in edx-platform
- Pin `click` and `packaging` versions to avoid conflict when upgrading requirements
- Bumped package version to `3.0.2` so platform can use latest dependencies.